### PR TITLE
fix(opencode): make AuthEntry fields optional for OAuth providers

### DIFF
--- a/tauri/src/coding/open_code/free_models.rs
+++ b/tauri/src/coding/open_code/free_models.rs
@@ -386,7 +386,9 @@ pub async fn get_provider_models_internal(state: &DbState, provider_id: &str) ->
 struct AuthEntry {
     #[serde(rename = "type")]
     auth_type: String,
-    key: String,
+    key: Option<String>,
+    access: Option<String>,
+    refresh: Option<String>,
 }
 
 /// Get auth.json file path: ~/.local/share/opencode/auth.json


### PR DESCRIPTION
auth.json may contain OAuth entries (like github-copilot) that have
access/refresh tokens instead of a key field, causing parsing to fail
and official auth channels to not display.

Fixed #7
