### PR TITLE
feat(claudecode): add dynamic model fetching for provider configuration

### DIFF
--- a/web/i18n/locales/en-US.json
+++ b/web/i18n/locales/en-US.json
@@ -625,6 +625,16 @@
       "tabManual": "Manual Configuration",
       "tabImport": "Import from OpenCode"
     },
+    "fetchModels": {
+      "button": "Fetch Models",
+      "loaded": "{{count}} model(s) loaded",
+      "success": "Successfully fetched {{count}} model(s)",
+      "noModels": "No models found",
+      "failed": "Failed to fetch models",
+      "baseUrlRequired": "Please enter Base URL first",
+      "openaiCompat": "OpenAI Compatible",
+      "native": "Anthropic Native"
+    },
     "apply": {
       "success": "Configuration applied successfully",
       "failed": "Failed to apply configuration",

--- a/web/i18n/locales/zh-CN.json
+++ b/web/i18n/locales/zh-CN.json
@@ -625,6 +625,16 @@
       "tabManual": "手动配置",
       "tabImport": "从 OpenCode 导入"
     },
+    "fetchModels": {
+      "button": "获取模型列表",
+      "loaded": "已加载 {{count}} 个模型",
+      "success": "成功获取 {{count}} 个模型",
+      "noModels": "未找到可用模型",
+      "failed": "获取模型列表失败",
+      "baseUrlRequired": "请先填写 Base URL",
+      "openaiCompat": "OpenAI 兼容",
+      "native": "Anthropic 原生"
+    },
     "apply": {
       "success": "配置应用成功",
       "failed": "配置应用失败",


### PR DESCRIPTION
## 问题背景 / Problem

在 ClaudeCode 供应商配置中，用户配置模型时需要手动输入模型 ID（如 `claude-sonnet-4-5-20250929`）。这带来了以下痛点：

1. **难以记忆**：Anthropic 模型 ID 包含版本号和日期，格式复杂难以记忆
2. **容易出错**：手动输入容易拼写错误，导致配置失败
3. **不知道有哪些模型**：用户不清楚当前供应商支持哪些模型

## 解决方案 / Solution

添加「获取模型列表」功能，用户可以：

1. **选择 API 类型**：支持 OpenAI 兼容 和 Anthropic 原生 两种模式
2. **一键获取模型**：点击按钮从供应商 API 动态获取可用模型列表
3. **下拉选择模型**：使用 AutoComplete 组件，支持搜索过滤和自由输入

## 变更内容 / Changes

- 将 4 个模型字段从 `Input` 改为 `AutoComplete` 组件
- 添加 API 类型选择器（OpenAI 兼容 / Anthropic 原生）
- 调用 `fetch_provider_models` API 动态获取模型列表
- 添加中英文 i18n 翻译

## 截图 / Screenshots

功能位置：ClaudeCode 页面 → 添加/编辑供应商 → 手动配置

## 测试步骤 / Test Plan

- [ ] 打开「添加供应商」弹窗，选择「手动配置」Tab
- [ ] 填写 Base URL 和 API Key
- [ ] 选择 API 类型（OpenAI 兼容 / Anthropic 原生）
- [ ] 点击「获取模型列表」按钮
- [ ] 验证模型字段下拉列表显示获取到的模型
- [ ] 验证可以搜索过滤模型
- [ ] 验证可以手动输入自定义模型 ID
- [ ] 编辑已有供应商时功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)