### PR TITLE
fix(claudecode): add missing isDisabled field in provider update

### DIFF
--- a/web/features/coding/claudecode/pages/ClaudeCodePage.tsx
+++ b/web/features/coding/claudecode/pages/ClaudeCodePage.tsx
@@ -279,6 +279,7 @@ const ClaudeCodePage: React.FC = () => {
           sourceProviderId: values.sourceProviderId,
           notes: values.notes,
           isApplied: editingProvider.isApplied,
+          isDisabled: editingProvider.isDisabled,
           createdAt: editingProvider.createdAt,
           updatedAt: editingProvider.updatedAt,
         });


### PR DESCRIPTION
  - 标题： fix(claudecode): add missing isDisabled field in provider update
  - 问题描述： 编辑供应商保存时报错 missing field isDisabled
  - 根因分析： PR #21 修改时遗漏了 isDisabled 字段
  - 修复方案： 添加 isDisabled: editingProvider.isDisabled