### PR TITLE
fix(wsl): improve sync robustness and fix symlink handling

### DIFF
--- a/tauri/src/coding/wsl/types.rs
+++ b/tauri/src/coding/wsl/types.rs
@@ -84,3 +84,23 @@ pub struct WSLStatusResult {
     pub last_sync_status: String,
     pub last_sync_error: Option<String>,
 }
+
+// ============================================================================
+// Sync Progress Types
+// ============================================================================
+
+/// Sync progress event payload (sent to frontend via Tauri events)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncProgress {
+    /// Current phase: "files" | "mcp" | "skills"
+    pub phase: String,
+    /// Current item being processed
+    pub current_item: String,
+    /// Current item index (1-based)
+    pub current: u32,
+    /// Total items in this phase
+    pub total: u32,
+    /// Overall progress message
+    pub message: String,
+}

--- a/web/features/settings/components/WSLSyncModal.tsx
+++ b/web/features/settings/components/WSLSyncModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Modal, Form, Switch, Select, Button, List, Space, Typography, Alert, Spin, Tag, Modal as AntdModal, Tabs, Tooltip } from 'antd';
+import { Modal, Form, Switch, Select, Button, List, Space, Typography, Alert, Spin, Tag, Modal as AntdModal, Tabs, Tooltip, Progress } from 'antd';
 import { CheckCircleOutlined, CloseCircleOutlined, ReloadOutlined, DeleteOutlined, EditOutlined, PlusOutlined, ClearOutlined, CodeOutlined, FolderOpenOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useWSLSync } from '@/features/settings/hooks/useWSLSync';
@@ -36,7 +36,7 @@ interface WSLSyncModalProps {
 
 export const WSLSyncModal: React.FC<WSLSyncModalProps> = ({ open, onClose }) => {
   const { t } = useTranslation();
-  const { config, status, loading, syncing, syncWarning, saveConfig, sync, detect, checkDistro, dismissSyncWarning } = useWSLSync();
+  const { config, status, loading, syncing, syncWarning, syncProgress, saveConfig, sync, detect, checkDistro, dismissSyncWarning } = useWSLSync();
 
   const [form] = Form.useForm();
   const [enabled, setEnabled] = useState(false);
@@ -488,6 +488,19 @@ export const WSLSyncModal: React.FC<WSLSyncModalProps> = ({ open, onClose }) => 
                   {t('settings.wsl.syncNow')}
                 </Button>
               </div>
+              {/* Sync Progress */}
+              {syncing && syncProgress && (
+                <div style={{ marginTop: 12 }}>
+                  <div style={{ marginBottom: 4 }}>
+                    <Text type="secondary">{syncProgress.message}</Text>
+                  </div>
+                  <Progress 
+                    percent={syncProgress.total > 0 ? Math.round((syncProgress.current / syncProgress.total) * 100) : 0}
+                    size="small"
+                    status="active"
+                  />
+                </div>
+              )}
               {status?.lastSyncError && (
                 <Alert
                   type="error"

--- a/web/types/wslsync.ts
+++ b/web/types/wslsync.ts
@@ -68,3 +68,19 @@ export interface WSLStatusResult {
   lastSyncStatus: string;
   lastSyncError?: string;
 }
+
+/**
+ * Sync progress event payload
+ */
+export interface SyncProgress {
+  /** Current phase: "files" | "mcp" | "skills" */
+  phase: string;
+  /** Current item being processed */
+  currentItem: string;
+  /** Current item index (1-based) */
+  current: number;
+  /** Total items in this phase */
+  total: number;
+  /** Overall progress message */
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Remove duplicate code in sync_skills_to_wsl function
- Remove unused check_distro_exists function
- Change sync command from \x27cp -r\x27 to \x27cp -rL\x27 to properly dereference symlinks during copy
- Add progress event reporting for MCP and skills sync operations
- Fix compilation errors and warnings in WSL sync modules

## Changes

### Backend
- tauri/src/coding/wsl/sync.rs: Fixed symlink handling with cp -rL, removed unused function
- tauri/src/coding/wsl/skills_sync.rs: Removed duplicate code (125 lines)
- tauri/src/coding/wsl/mcp_sync.rs: Added progress event reporting
- tauri/src/coding/wsl/commands.rs: Integrated progress reporting
- tauri/src/coding/wsl/types.rs: Added SyncProgress type

### Frontend
- web/features/settings/hooks/useWSLSync.ts: Progress state management
- web/features/settings/components/WSLSyncModal.tsx: Progress UI
- web/types/wslsync.ts: Type definitions

Fixes #43