### PR TITLE
on-my-opencode模型测试功能漏洞

### DIFF
--- a/tauri/src/coding/open_code/models_api.rs
+++ b/tauri/src/coding/open_code/models_api.rs
@@ -485,7 +485,7 @@ fn build_connectivity_url(
 ) -> String {
     let base = normalize_base_url(base_url);
     match npm {
-        "@ai-sdk/openai" => format!("{}/v1/responses", base),
+        "@ai-sdk/openai" => format!("{}/v1/chat/completions", base),
         "@ai-sdk/google" => {
             let normalized_model = model_id.strip_prefix("models/").unwrap_or(model_id);
             let action = if stream { "streamGenerateContent" } else { "generateContent" };
@@ -582,14 +582,16 @@ fn build_default_body(
         "@ai-sdk/openai" => {
             let mut body = json!({
                 "model": model_id,
-                "input": request.prompt,
+                "messages": [
+            { "role": "user", "content": request.prompt }
+        ],
                 "stream": stream_enabled,
             });
             if let Some(temperature) = request.temperature {
                 body["temperature"] = json!(temperature);
             }
             if let Some(max_tokens) = request.max_tokens {
-                body["max_output_tokens"] = json!(max_tokens);
+                body["max_tokens"] = json!(max_tokens);
             }
             body
         }
@@ -637,7 +639,9 @@ fn enforce_prompt_and_model(npm: &str, body: &mut Value, model_id: &str, prompt:
         }
         "@ai-sdk/openai" => {
             body["model"] = json!(model_id);
-            body["input"] = json!(prompt);
+             body["messages"] = json!([
+        { "role": "user", "content": prompt }
+    ]);
         }
         "@ai-sdk/openai-compatible" => {
             body["model"] = json!(model_id);


### PR DESCRIPTION
中转站来源：right.codes
使用模型：GPT Codex全家桶
问题：当NPM包为openai的时候测试模型，在开关流式传输下都会默认全红,但是实际上在cli内调用可以正常使用。

"body": [
      {
        "detail": "Input must be a list"
      }
    ]

经过测试貌似是input类型需要为[ ]才能作为数组传递，或者使用"input": messages, 修改前后效果图
（调了一个通宵的opencode配置，为了模型能跑通选了openai兼容NPM，结果tools函数全部自爆，我一度以为被L佬诈骗买了个残疾人中转节点 昏迷了）
<img width="1368" height="745" alt="Image" src="https://github.com/user-attachments/assets/e706df9d-3542-489e-a415-d920a6c55601" />

<img width="922" height="439" alt="Image" src="https://github.com/user-attachments/assets/e0c2b851-9bef-4e75-aac0-495c7cebe0bd" />