### PR TITLE
feat: 添加代理启用开关，解决本地服务访问问题

### DIFF
--- a/tauri/src/coding/skills/commands.rs
+++ b/tauri/src/coding/skills/commands.rs
@@ -304,7 +304,8 @@ pub async fn skills_list_git_skills(
     branch: Option<String>,
 ) -> Result<Vec<GitSkillCandidate>, String> {
     // Initialize proxy from app settings
-    let proxy_url = http_client::get_proxy_from_settings(&state).await.ok();
+    let proxy_result = http_client::get_proxy_from_settings(&state).await.ok();
+    let proxy_url = proxy_result.map(|(enabled, url)| if enabled && !url.is_empty() { Some(url) } else { None }).flatten();
     set_proxy(proxy_url);
 
     let ttl = get_git_cache_ttl_secs(&state).await;

--- a/tauri/src/coding/skills/installer.rs
+++ b/tauri/src/coding/skills/installer.rs
@@ -997,6 +997,7 @@ fn repo_cache_key(clone_url: &str, branch: Option<&str>) -> String {
 
 /// Initialize proxy settings from app settings database
 async fn init_proxy_from_settings(state: &DbState) {
-    let proxy_url = http_client::get_proxy_from_settings(state).await.ok();
+    let proxy_result = http_client::get_proxy_from_settings(state).await.ok();
+    let proxy_url = proxy_result.and_then(|(enabled, url)| if enabled && !url.is_empty() { Some(url) } else { None });
     set_proxy(proxy_url);
 }

--- a/tauri/src/http_client.rs
+++ b/tauri/src/http_client.rs
@@ -59,8 +59,8 @@ pub async fn client(db_state: &DbState) -> Result<Client, String> {
 /// let client = http_client::client_with_timeout(&state, 60).await?;
 /// ```
 pub async fn client_with_timeout(db_state: &DbState, timeout_secs: u64) -> Result<Client, String> {
-    let proxy_url = get_proxy_from_settings(db_state).await?;
-    build_client(&proxy_url, timeout_secs)
+    let (proxy_enabled, proxy_url) = get_proxy_from_settings(db_state).await?;
+    build_client(proxy_enabled, &proxy_url, timeout_secs)
 }
 
 /// Build an HTTP client with explicit proxy URL.
@@ -68,6 +68,7 @@ pub async fn client_with_timeout(db_state: &DbState, timeout_secs: u64) -> Resul
 /// This is an internal function. Business code should use `client()` or `client_with_timeout()`.
 ///
 /// # Arguments
+/// * `proxy_enabled` - Whether proxy is enabled by user
 /// * `proxy_url` - Proxy URL (e.g., "http://proxy.com:8080" or "socks5://proxy.com:1080")
 ///                 Empty string means use system proxy (Windows/macOS) or env vars (Linux)
 /// * `timeout_secs` - Request timeout in seconds
@@ -76,19 +77,22 @@ pub async fn client_with_timeout(db_state: &DbState, timeout_secs: u64) -> Resul
 /// A configured reqwest::Client
 ///
 /// # Proxy Priority
-/// 1. User-configured proxy (if proxy_url is not empty)
-/// 2. System proxy (Windows/macOS) or environment variables (Linux)
-/// 3. Direct connection (if no proxy available)
-fn build_client(proxy_url: &str, timeout_secs: u64) -> Result<Client, String> {
+/// 1. If proxy_enabled is false: explicitly disable all proxies (including system proxy)
+/// 2. If proxy_enabled is true and proxy_url is not empty: use user-configured proxy
+/// 3. If proxy_enabled is true and proxy_url is empty: use system proxy (Windows/macOS) or env vars (Linux)
+fn build_client(proxy_enabled: bool, proxy_url: &str, timeout_secs: u64) -> Result<Client, String> {
     let mut builder = Client::builder().timeout(Duration::from_secs(timeout_secs));
 
-    if !proxy_url.is_empty() {
+    if !proxy_enabled {
+        // User explicitly disabled proxy - bypass all proxies including system proxy
+        builder = builder.no_proxy();
+    } else if !proxy_url.is_empty() {
         // User-configured proxy takes priority over system proxy
         if let Some(proxy) = build_proxy(proxy_url)? {
             builder = builder.proxy(proxy);
         }
     }
-    // If proxy_url is empty, system-proxy feature automatically detects system proxy
+    // If proxy_enabled is true and proxy_url is empty, system-proxy feature automatically detects system proxy
 
     builder
         .build()
@@ -126,8 +130,8 @@ pub async fn test_proxy(proxy_url: &str) -> Result<(), String> {
         return Err("Proxy URL is empty".to_string());
     }
 
-    // Create client with proxy
-    let client = build_client(proxy_url, 10)?;
+    // Create client with proxy enabled
+    let client = build_client(true, proxy_url, 10)?;
 
     // Test with httpbin.org - it's designed for testing HTTP clients
     let response = client
@@ -146,21 +150,21 @@ pub async fn test_proxy(proxy_url: &str) -> Result<(), String> {
     }
 }
 
-/// Read proxy URL from database settings.
+/// Read proxy settings from database.
 ///
 /// This is a public function that can be used by any module needing proxy configuration.
-/// Returns an empty string if no proxy is configured.
+/// Returns (proxy_enabled, proxy_url) tuple.
 ///
 /// # Arguments
 /// * `db_state` - Database state to read proxy settings from
 ///
 /// # Returns
-/// Proxy URL string (empty if not configured)
-pub async fn get_proxy_from_settings(db_state: &DbState) -> Result<String, String> {
+/// Tuple of (proxy_enabled: bool, proxy_url: String)
+pub async fn get_proxy_from_settings(db_state: &DbState) -> Result<(bool, String), String> {
     let db = db_state.db();
 
     let mut result = db
-        .query("SELECT proxy_url OMIT id FROM settings:`app` LIMIT 1")
+        .query("SELECT proxy_enabled, proxy_url OMIT id FROM settings:`app` LIMIT 1")
         .await
         .map_err(|e| format!("Failed to query proxy settings: {}", e))?;
 
@@ -169,13 +173,18 @@ pub async fn get_proxy_from_settings(db_state: &DbState) -> Result<String, Strin
         .map_err(|e| format!("Failed to parse proxy settings: {}", e))?;
 
     if let Some(record) = records.first() {
-        Ok(record
+        let proxy_enabled = record
+            .get("proxy_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let proxy_url = record
             .get("proxy_url")
             .and_then(|v| v.as_str())
             .unwrap_or("")
-            .to_string())
+            .to_string();
+        Ok((proxy_enabled, proxy_url))
     } else {
-        Ok(String::new())
+        Ok((false, String::new()))
     }
 }
 

--- a/tauri/src/settings/adapter.rs
+++ b/tauri/src/settings/adapter.rs
@@ -24,6 +24,7 @@ pub fn from_db_value(value: Value) -> AppSettings {
         launch_on_startup: get_bool(&value, "launch_on_startup", true),
         minimize_to_tray_on_close: get_bool(&value, "minimize_to_tray_on_close", true),
         start_minimized: get_bool(&value, "start_minimized", false),
+        proxy_enabled: get_bool(&value, "proxy_enabled", false),
         proxy_url: get_str(&value, "proxy_url", ""),
         theme: get_str(&value, "theme", "system"),
         auto_backup_enabled: get_bool(&value, "auto_backup_enabled", false),

--- a/tauri/src/settings/types.rs
+++ b/tauri/src/settings/types.rs
@@ -44,6 +44,8 @@ pub struct AppSettings {
     pub minimize_to_tray_on_close: bool,
     /// Start minimized to tray (default: false)
     pub start_minimized: bool,
+    /// Enable proxy for network requests (default: false)
+    pub proxy_enabled: bool,
     /// Proxy URL for network requests (e.g., http://user:pass@proxy.com:8080 or socks5://proxy.com:1080)
     pub proxy_url: String,
     /// Theme mode: "light", "dark", or "system" (default: "system")
@@ -78,6 +80,7 @@ impl Default for AppSettings {
             launch_on_startup: true,
             minimize_to_tray_on_close: true,
             start_minimized: false,
+            proxy_enabled: false,
             proxy_url: String::new(),
             theme: "system".to_string(),
             auto_backup_enabled: false,

--- a/tauri/src/update.rs
+++ b/tauri/src/update.rs
@@ -134,15 +134,15 @@ pub async fn install_update(
     app: tauri::AppHandle,
     state: tauri::State<'_, DbState>,
 ) -> Result<bool, String> {
-    // Get proxy URL from settings for updater plugin
-    let proxy_url = http_client::get_proxy_from_settings(&state).await?;
+    // Get proxy settings from database
+    let (proxy_enabled, proxy_url) = http_client::get_proxy_from_settings(&state).await?;
 
     // Set proxy environment variables for the updater plugin
     // (tauri-plugin-updater reads these env vars for proxy configuration)
     let old_http_proxy = std::env::var("HTTP_PROXY").ok();
     let old_https_proxy = std::env::var("HTTPS_PROXY").ok();
 
-    if !proxy_url.is_empty() {
+    if proxy_enabled && !proxy_url.is_empty() {
         std::env::set_var("HTTP_PROXY", &proxy_url);
         std::env::set_var("HTTPS_PROXY", &proxy_url);
     }
@@ -248,12 +248,12 @@ pub async fn install_update(
     // Restore original environment variables
     if let old @ Some(_) = old_http_proxy {
         std::env::set_var("HTTP_PROXY", old.unwrap());
-    } else if !proxy_url.is_empty() {
+    } else if proxy_enabled && !proxy_url.is_empty() {
         std::env::remove_var("HTTP_PROXY");
     }
     if let old @ Some(_) = old_https_proxy {
         std::env::set_var("HTTPS_PROXY", old.unwrap());
-    } else if !proxy_url.is_empty() {
+    } else if proxy_enabled && !proxy_url.is_empty() {
         std::env::remove_var("HTTPS_PROXY");
     }
 

--- a/web/features/settings/pages/GeneralSettingsPage.tsx
+++ b/web/features/settings/pages/GeneralSettingsPage.tsx
@@ -132,6 +132,8 @@ const GeneralSettingsPage: React.FC = () => {
     setStartMinimized,
     proxyUrl,
     setProxyUrl,
+    proxyEnabled,
+    setProxyEnabled,
     autoBackupEnabled,
     autoBackupIntervalDays,
     lastAutoBackupTime,
@@ -854,6 +856,13 @@ const GeneralSettingsPage: React.FC = () => {
             {/* Proxy Settings */}
             <SectionTitle icon={<ApiOutlined style={{ color: '#fa8c16' }} />} title={t('settings.cards.proxy')} />
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 16 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Text>{t('settings.proxy.enableProxy')}</Text>
+                <Switch
+                  checked={proxyEnabled}
+                  onChange={setProxyEnabled}
+                />
+              </div>
               <div style={{ display: 'flex', gap: 8 }}>
                 <Input
                   value={proxyInput}
@@ -862,10 +871,12 @@ const GeneralSettingsPage: React.FC = () => {
                   onPressEnter={handleProxySave}
                   placeholder={t('settings.proxy.urlPlaceholder')}
                   style={{ flex: 1 }}
+                  disabled={!proxyEnabled}
                 />
                 <Button
                   onClick={handleProxyTest}
                   loading={proxyTesting}
+                  disabled={!proxyEnabled || !proxyInput}
                 >
                   {proxyTesting ? t('settings.proxy.testing') : t('settings.proxy.testConnection')}
                 </Button>

--- a/web/i18n/locales/en-US.json
+++ b/web/i18n/locales/en-US.json
@@ -397,6 +397,7 @@
 		},
 		"proxy": {
 			"title": "Network Proxy",
+			"enableProxy": "Enable Proxy",
 			"urlPlaceholder": "http://user:pass@proxy.example.com:8080",
 			"hint": "Supports HTTP and SOCKS5 proxies, with optional username and password, e.g., http://user:pass@proxy.example.com:8080",
 			"testConnection": "Test Connection",

--- a/web/i18n/locales/zh-CN.json
+++ b/web/i18n/locales/zh-CN.json
@@ -397,6 +397,7 @@
 		},
 		"proxy": {
 			"title": "网络代理",
+			"enableProxy": "启用代理",
 			"urlPlaceholder": "http://user:pass@proxy.example.com:8080",
 			"hint": "支持 HTTP 和 SOCKS5 代理，可包含用户名密码，示例：http://user:pass@proxy.example.com:8080",
 			"testConnection": "测试连接",

--- a/web/services/settingsApi.ts
+++ b/web/services/settingsApi.ts
@@ -75,6 +75,7 @@ export interface AppSettings {
   launch_on_startup: boolean;
   minimize_to_tray_on_close: boolean;
   start_minimized: boolean;
+  proxy_enabled: boolean;
   proxy_url: string;
   theme: string;
   auto_backup_enabled: boolean;
@@ -114,6 +115,7 @@ export const defaultSettings: AppSettings = {
   launch_on_startup: true,
   minimize_to_tray_on_close: true,
   start_minimized: false,
+  proxy_enabled: false,
   proxy_url: '',
   theme: 'system',
   auto_backup_enabled: false,

--- a/web/stores/settingsStore.ts
+++ b/web/stores/settingsStore.ts
@@ -51,6 +51,7 @@ interface SettingsState {
   startMinimized: boolean;
 
   // Proxy settings
+  proxyEnabled: boolean;
   proxyUrl: string;
 
   // Auto backup settings
@@ -80,6 +81,7 @@ interface SettingsState {
   setLaunchOnStartup: (enabled: boolean) => Promise<void>;
   setMinimizeToTrayOnClose: (enabled: boolean) => Promise<void>;
   setStartMinimized: (enabled: boolean) => Promise<void>;
+  setProxyEnabled: (enabled: boolean) => Promise<void>;
   setProxyUrl: (url: string) => Promise<void>;
   setAutoBackupSettings: (config: {
     enabled: boolean;
@@ -162,6 +164,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   launchOnStartup: true,
   minimizeToTrayOnClose: true,
   startMinimized: false,
+  proxyEnabled: false,
   proxyUrl: '',
   autoBackupEnabled: false,
   autoBackupIntervalDays: 7,
@@ -186,6 +189,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
         launchOnStartup: settings.launch_on_startup,
         minimizeToTrayOnClose: settings.minimize_to_tray_on_close,
         startMinimized: settings.start_minimized ?? false,
+        proxyEnabled: settings.proxy_enabled ?? false,
         proxyUrl: settings.proxy_url || '',
         autoBackupEnabled: settings.auto_backup_enabled ?? false,
         autoBackupIntervalDays: settings.auto_backup_interval_days ?? 7,
@@ -289,6 +293,18 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     const newSettings: AppSettings = {
       ...currentSettings,
       start_minimized: enabled,
+    };
+    await saveSettings(newSettings);
+  },
+
+  setProxyEnabled: async (enabled) => {
+    set({ proxyEnabled: enabled });
+
+    // Update database
+    const currentSettings = await getSettings();
+    const newSettings: AppSettings = {
+      ...currentSettings,
+      proxy_enabled: enabled,
     };
     await saveSettings(newSettings);
   },


### PR DESCRIPTION
- 新增 proxy_enabled 配置项，允许用户完全禁用代理
- 修改 http_client 逻辑，支持三种代理模式：
  1. 禁用代理（绕过系统代理）
  2. 使用自定义代理
  3. 使用系统代理
- 前端添加代理启用开关UI
- 添加中英文国际化文本
- 修复所有相关模块的代理调用

修复问题：
- 解决 127.0.0.1 本地服务因系统代理导致的 502 错误
- 用户可通过关闭代理开关直接访问本地服务