### PR TITLE
更新 GitHub Copilot的MCP 配置路径（提供intellij支持）

### DIFF
--- a/tauri/Cargo.lock
+++ b/tauri/Cargo.lock
@@ -9929,4 +9929,3 @@ dependencies = [
  "syn 2.0.114",
  "winnow 0.7.14",
 ]
-

--- a/tauri/src/coding/mcp/adapter.rs
+++ b/tauri/src/coding/mcp/adapter.rs
@@ -7,6 +7,13 @@ use serde_json::Value;
 use super::types::{FavoriteMcp, McpPreferences, McpServer, McpSyncDetail, McpSyncDetailDto};
 use crate::coding::db_extract_id;
 
+fn normalize_tool_key(key: &str) -> String {
+    match key {
+        "github_copilot_intellij" => "github_copilot".to_string(),
+        _ => key.to_string(),
+    }
+}
+
 /// Convert database record to McpServer struct
 pub fn from_db_mcp_server(value: Value) -> McpServer {
     let enabled_tools: Vec<String> = value
@@ -14,7 +21,7 @@ pub fn from_db_mcp_server(value: Value) -> McpServer {
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                .filter_map(|item| item.as_str().map(normalize_tool_key))
                 .collect()
         })
         .unwrap_or_default();
@@ -98,7 +105,7 @@ pub fn parse_sync_details(server: &McpServer) -> Vec<McpSyncDetail> {
 
     obj.iter()
         .map(|(tool_key, entry)| McpSyncDetail {
-            tool: tool_key.clone(),
+            tool: normalize_tool_key(tool_key),
             status: entry
                 .get("status")
                 .and_then(|v| v.as_str())
@@ -169,7 +176,7 @@ pub fn from_db_mcp_preferences(value: Value) -> McpPreferences {
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(normalize_tool_key))
                     .collect()
             })
             .unwrap_or_default(),

--- a/tauri/src/coding/mcp/commands.rs
+++ b/tauri/src/coding/mcp/commands.rs
@@ -18,8 +18,8 @@ use super::types::{
 };
 use crate::coding::tools::{
     custom_store, get_mcp_runtime_tools, is_tool_installed_with_db_async,
-    resolve_mcp_config_path_with_db_async, runtime_tool_by_key, to_runtime_tool_dto_with_db_async,
-    CustomTool, RuntimeToolDto,
+    resolve_mcp_config_path_with_db_async, resolve_mcp_config_paths_with_db_async,
+    runtime_tool_by_key, to_runtime_tool_dto_with_db_async, CustomTool, RuntimeToolDto,
 };
 use crate::DbState;
 
@@ -662,15 +662,22 @@ async fn mcp_scan_servers_inner(state: &DbState) -> Result<McpScanResultDto, Str
             continue;
         }
 
-        let Some(config_path) = resolve_mcp_config_path_with_db_async(&scan_db, tool).await else {
-            continue;
+        let config_paths = if tool.key == "github_copilot" {
+            resolve_mcp_config_paths_with_db_async(&scan_db, tool).await
+        } else {
+            resolve_mcp_config_path_with_db_async(&scan_db, tool)
+                .await
+                .into_iter()
+                .collect()
         };
 
-        if !config_path.exists() {
-            continue;
-        }
+        for config_path in config_paths {
+            if !config_path.exists() {
+                continue;
+            }
 
-        scan_targets.push((tool.clone(), config_path));
+            scan_targets.push((tool.clone(), config_path));
+        }
     }
 
     // Run the blocking file system operations in a dedicated thread pool
@@ -678,6 +685,7 @@ async fn mcp_scan_servers_inner(state: &DbState) -> Result<McpScanResultDto, Str
     let scan_result = tokio::task::spawn_blocking(move || {
         let mut total_tools_scanned = 0;
         let mut servers: Vec<McpDiscoveredServerDto> = Vec::new();
+        let mut seen_servers = std::collections::HashSet::new();
 
         for (tool, config_path) in &scan_targets {
             eprintln!("[DEBUG][mcp_scan_servers] scanning tool: {}", tool.key);
@@ -694,6 +702,16 @@ async fn mcp_scan_servers_inner(state: &DbState) -> Result<McpScanResultDto, Str
                     for server in imported {
                         // Skip servers that already exist in the database
                         if existing_names.contains(&server.name) {
+                            continue;
+                        }
+                        let fingerprint = format!(
+                            "{}::{}::{}::{}",
+                            tool.key,
+                            server.name,
+                            server.server_type,
+                            serde_json::to_string(&server.server_config).unwrap_or_default()
+                        );
+                        if !seen_servers.insert(fingerprint) {
                             continue;
                         }
                         servers.push(McpDiscoveredServerDto {

--- a/tauri/src/coding/mcp/config_sync.rs
+++ b/tauri/src/coding/mcp/config_sync.rs
@@ -4,7 +4,8 @@
 //! Supports JSON/JSONC (unified with json5) and TOML formats.
 //! Also handles format conversion for tools like OpenCode that use different schemas.
 
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
@@ -12,9 +13,64 @@ use super::command_normalize;
 use super::format_configs::get_format_config;
 use super::types::{now_ms, McpServer, McpSyncDetail};
 use crate::coding::tools::{
-    resolve_mcp_config_path_with_db, resolve_mcp_config_path_with_db_async, McpFormatConfig,
+    resolve_mcp_config_path_with_db, resolve_mcp_config_path_with_db_async,
+    resolve_mcp_config_paths_with_db, resolve_mcp_config_paths_with_db_async, McpFormatConfig,
     RuntimeTool,
 };
+
+fn existing_sync_target_paths(config_paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    config_paths
+        .into_iter()
+        .filter(|path| path.exists() || path.parent().map(|parent| parent.exists()).unwrap_or(false))
+        .collect()
+}
+
+fn github_copilot_path_label(path: &Path) -> &'static str {
+    let path_str = path.to_string_lossy().to_lowercase();
+    if path_str.contains("intellij") {
+        "IntelliJ"
+    } else {
+        "VSCode"
+    }
+}
+
+fn merge_imported_servers(
+    merged: &mut HashMap<String, McpServer>,
+    imported: Vec<McpServer>,
+    source_label: &str,
+) {
+    for mut server in imported {
+        match merged.get(&server.name) {
+            Some(existing)
+                if existing.server_type == server.server_type
+                    && existing.server_config == server.server_config =>
+            {
+                continue;
+            }
+            Some(_) => {
+                let original_name = server.name.clone();
+                let mut index = 1;
+                loop {
+                    let candidate = if index == 1 {
+                        format!("{} ({})", original_name, source_label)
+                    } else {
+                        format!("{} ({}) {}", original_name, source_label, index)
+                    };
+
+                    if !merged.contains_key(&candidate) {
+                        server.name = candidate;
+                        break;
+                    }
+
+                    index += 1;
+                }
+            }
+            None => {}
+        }
+
+        merged.insert(server.name.clone(), server);
+    }
+}
 
 /// Sync an MCP server to a specific tool's config file
 pub fn sync_server_to_tool(
@@ -40,6 +96,31 @@ pub fn sync_server_to_tool_with_enabled(
     tool: &RuntimeTool,
     enabled: bool,
 ) -> Result<McpSyncDetail, String> {
+    if tool.key == "github_copilot" {
+        let config_paths = existing_sync_target_paths(resolve_mcp_config_paths_with_db(db, tool));
+        if config_paths.is_empty() {
+            return Err("Tool github_copilot does not have any detected MCP config locations".to_string());
+        }
+
+        let mut errors = Vec::new();
+        for config_path in config_paths {
+            if let Err(err) = sync_server_to_path(tool, &config_path, server, enabled) {
+                errors.push(format!("{}: {}", config_path.to_string_lossy(), err));
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+
+        return Ok(McpSyncDetail {
+            tool: tool.key.clone(),
+            status: "ok".to_string(),
+            synced_at: Some(now_ms()),
+            error_message: None,
+        });
+    }
+
     let config_path = resolve_mcp_config_path_with_db(db, tool)
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
     sync_server_to_path(tool, &config_path, server, enabled)
@@ -51,6 +132,32 @@ pub async fn sync_server_to_tool_with_enabled_async(
     tool: &RuntimeTool,
     enabled: bool,
 ) -> Result<McpSyncDetail, String> {
+    if tool.key == "github_copilot" {
+        let config_paths =
+            existing_sync_target_paths(resolve_mcp_config_paths_with_db_async(db, tool).await);
+        if config_paths.is_empty() {
+            return Err("Tool github_copilot does not have any detected MCP config locations".to_string());
+        }
+
+        let mut errors = Vec::new();
+        for config_path in config_paths {
+            if let Err(err) = sync_server_to_path(tool, &config_path, server, enabled) {
+                errors.push(format!("{}: {}", config_path.to_string_lossy(), err));
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+
+        return Ok(McpSyncDetail {
+            tool: tool.key.clone(),
+            status: "ok".to_string(),
+            synced_at: Some(now_ms()),
+            error_message: None,
+        });
+    }
+
     let config_path = resolve_mcp_config_path_with_db_async(db, tool)
         .await
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
@@ -63,6 +170,26 @@ pub fn remove_server_from_tool(
     server_name: &str,
     tool: &RuntimeTool,
 ) -> Result<(), String> {
+    if tool.key == "github_copilot" {
+        let config_paths = resolve_mcp_config_paths_with_db(db, tool);
+        if config_paths.is_empty() {
+            return Err(format!("Tool {} does not support MCP", tool.key));
+        }
+
+        let mut errors = Vec::new();
+        for config_path in config_paths {
+            if let Err(err) = remove_server_from_path(tool, &config_path, server_name) {
+                errors.push(format!("{}: {}", config_path.to_string_lossy(), err));
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+
+        return Ok(());
+    }
+
     let config_path = resolve_mcp_config_path_with_db(db, tool)
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
     remove_server_from_path(tool, &config_path, server_name)
@@ -73,6 +200,26 @@ pub async fn remove_server_from_tool_async(
     server_name: &str,
     tool: &RuntimeTool,
 ) -> Result<(), String> {
+    if tool.key == "github_copilot" {
+        let config_paths = resolve_mcp_config_paths_with_db_async(db, tool).await;
+        if config_paths.is_empty() {
+            return Err(format!("Tool {} does not support MCP", tool.key));
+        }
+
+        let mut errors = Vec::new();
+        for config_path in config_paths {
+            if let Err(err) = remove_server_from_path(tool, &config_path, server_name) {
+                errors.push(format!("{}: {}", config_path.to_string_lossy(), err));
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+
+        return Ok(());
+    }
+
     let config_path = resolve_mcp_config_path_with_db_async(db, tool)
         .await
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
@@ -608,6 +755,19 @@ pub fn import_servers_from_tool(
     db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
     tool: &RuntimeTool,
 ) -> Result<Vec<McpServer>, String> {
+    if tool.key == "github_copilot" {
+        let mut merged = HashMap::new();
+        for config_path in resolve_mcp_config_paths_with_db(db, tool) {
+            let imported = import_servers_from_path(tool, &config_path)?;
+            merge_imported_servers(
+                &mut merged,
+                imported,
+                github_copilot_path_label(&config_path),
+            );
+        }
+        return Ok(merged.into_values().collect());
+    }
+
     let config_path = resolve_mcp_config_path_with_db(db, tool)
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
     import_servers_from_path(tool, &config_path)
@@ -617,6 +777,19 @@ pub async fn import_servers_from_tool_async(
     db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
     tool: &RuntimeTool,
 ) -> Result<Vec<McpServer>, String> {
+    if tool.key == "github_copilot" {
+        let mut merged = HashMap::new();
+        for config_path in resolve_mcp_config_paths_with_db_async(db, tool).await {
+            let imported = import_servers_from_path(tool, &config_path)?;
+            merge_imported_servers(
+                &mut merged,
+                imported,
+                github_copilot_path_label(&config_path),
+            );
+        }
+        return Ok(merged.into_values().collect());
+    }
+
     let config_path = resolve_mcp_config_path_with_db_async(db, tool)
         .await
         .ok_or_else(|| format!("Tool {} does not support MCP", tool.key))?;
@@ -993,3 +1166,67 @@ fn import_servers_from_toml(config_path: &PathBuf, field: &str) -> Result<Vec<Mc
 
     Ok(servers)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn build_server(name: &str, server_config: Value) -> McpServer {
+        McpServer {
+            id: String::new(),
+            name: name.to_string(),
+            server_type: "stdio".to_string(),
+            server_config,
+            enabled_tools: vec![],
+            sync_details: None,
+            description: None,
+            tags: vec![],
+            timeout: None,
+            sort_index: 0,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_merge_imported_servers_github_copilot_dedupes_identical_configs() {
+        let mut merged = HashMap::new();
+
+        merge_imported_servers(
+            &mut merged,
+            vec![build_server("demo", json!({ "command": "npx", "args": ["-y", "demo"] }))],
+            "VSCode",
+        );
+        merge_imported_servers(
+            &mut merged,
+            vec![build_server("demo", json!({ "command": "npx", "args": ["-y", "demo"] }))],
+            "IntelliJ",
+        );
+
+        assert_eq!(merged.len(), 1);
+        assert!(merged.contains_key("demo"));
+    }
+
+    #[test]
+    fn test_merge_imported_servers_github_copilot_suffixes_conflicting_names() {
+        let mut merged = HashMap::new();
+
+        merge_imported_servers(
+            &mut merged,
+            vec![build_server("demo", json!({ "command": "npx", "args": ["-y", "demo-a"] }))],
+            "VSCode",
+        );
+        merge_imported_servers(
+            &mut merged,
+            vec![build_server("demo", json!({ "command": "npx", "args": ["-y", "demo-b"] }))],
+            "IntelliJ",
+        );
+
+        assert_eq!(merged.len(), 2);
+        assert!(merged.contains_key("demo"));
+        assert!(merged.contains_key("demo (IntelliJ)"));
+    }
+}
+

--- a/tauri/src/coding/tools/builtin.rs
+++ b/tauri/src/coding/tools/builtin.rs
@@ -119,7 +119,8 @@ pub const BUILTIN_TOOLS: &[BuiltinTool] = &[
         mcp_field: None,
     },
     // GitHub Copilot - supports both Skills and MCP
-    // MCP path uses VSCode plugin config path (same as Amp)
+    // MCP sync uses the VSCode plugin config path as primary path and may also
+    // update other GitHub Copilot plugin locations (for example IntelliJ)
     BuiltinTool {
         key: "github_copilot",
         display_name: "GitHub Copilot",
@@ -184,5 +185,10 @@ pub fn get_mcp_builtin_tools() -> Vec<&'static BuiltinTool> {
 
 /// Find a built-in tool by key
 pub fn builtin_tool_by_key(key: &str) -> Option<&'static BuiltinTool> {
-    BUILTIN_TOOLS.iter().find(|t| t.key == key)
+    let normalized_key = match key {
+        "github_copilot_intellij" => "github_copilot",
+        _ => key,
+    };
+
+    BUILTIN_TOOLS.iter().find(|t| t.key == normalized_key)
 }

--- a/tauri/src/coding/tools/detection.rs
+++ b/tauri/src/coding/tools/detection.rs
@@ -8,6 +8,105 @@ use super::builtin::BUILTIN_TOOLS;
 use super::path_utils::{resolve_storage_path, to_platform_path};
 use super::types::{CustomTool, RuntimeTool, RuntimeToolDto, ToolDetectionDto};
 
+fn resolve_github_copilot_intellij_mcp_path() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        return dirs::config_dir().map(|config_dir| {
+            config_dir
+                .join("github-copilot")
+                .join("intellij")
+                .join("mcp.json")
+        });
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return dirs::data_local_dir().map(|local_data_dir| {
+            local_data_dir
+                .join("github-copilot")
+                .join("intellij")
+                .join("mcp.json")
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return dirs::config_dir().map(|config_dir| {
+            config_dir
+                .join("GitHub Copilot")
+                .join("intellij")
+                .join("mcp.json")
+        });
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+fn resolve_special_mcp_config_paths(tool: &RuntimeTool) -> Option<Vec<PathBuf>> {
+    match tool.key.as_str() {
+        // OpenCode uses dynamic path resolution
+        "opencode" => crate::coding::mcp::opencode_path::get_opencode_mcp_config_path_sync()
+            .map(|path| vec![path]),
+        // GitHub Copilot should sync to all known plugin MCP locations on the current OS
+        "github_copilot" => {
+            let mut paths = Vec::new();
+
+            if let Some(vscode_path) = tool
+                .mcp_config_path
+                .as_ref()
+                .and_then(|path| resolve_storage_path(path))
+            {
+                paths.push(vscode_path);
+            }
+
+            if let Some(intellij_path) = resolve_github_copilot_intellij_mcp_path() {
+                paths.push(intellij_path);
+            }
+
+            Some(paths)
+        }
+        _ => None,
+    }
+}
+
+pub fn resolve_mcp_config_paths(tool: &RuntimeTool) -> Vec<PathBuf> {
+    if let Some(paths) = resolve_special_mcp_config_paths(tool) {
+        return paths;
+    }
+
+    tool.mcp_config_path
+        .as_ref()
+        .and_then(|path| resolve_storage_path(path))
+        .into_iter()
+        .collect()
+}
+
+fn select_preferred_mcp_config_path(paths: Vec<PathBuf>) -> Option<PathBuf> {
+    let mut first_path = None;
+    let mut parent_existing_path = None;
+
+    for path in paths {
+        if first_path.is_none() {
+            first_path = Some(path.clone());
+        }
+
+        if path.exists() {
+            return Some(path);
+        }
+
+        if parent_existing_path.is_none()
+            && path.parent().map(|parent| parent.exists()).unwrap_or(false)
+        {
+            parent_existing_path = Some(path);
+        }
+    }
+
+    parent_existing_path.or(first_path)
+}
+
 /// Check if a runtime tool is installed by checking its detect directory
 pub fn is_tool_installed(tool: &RuntimeTool) -> bool {
     // Custom tools are always considered installed
@@ -15,22 +114,16 @@ pub fn is_tool_installed(tool: &RuntimeTool) -> bool {
         return true;
     }
 
-    // Special handling for OpenCode - use dynamic path resolution
-    if tool.key == "opencode" {
-        if let Some(config_path) =
-            crate::coding::mcp::opencode_path::get_opencode_mcp_config_path_sync()
-        {
-            // Check if the config file or its parent directory exists
-            if config_path.exists() {
+    for config_path in resolve_mcp_config_paths(tool) {
+        // Check if the config file or its parent directory exists
+        if config_path.exists() {
+            return true;
+        }
+        if let Some(parent) = config_path.parent() {
+            if parent.exists() {
                 return true;
             }
-            if let Some(parent) = config_path.parent() {
-                if parent.exists() {
-                    return true;
-                }
-            }
         }
-        // Fall through to default detection
     }
 
     if let Some(ref detect_dir) = tool.relative_detect_dir {
@@ -52,27 +145,42 @@ pub fn resolve_skills_path(tool: &RuntimeTool) -> Option<PathBuf> {
 
 /// Resolve the MCP config path for a tool
 pub fn resolve_mcp_config_path(tool: &RuntimeTool) -> Option<PathBuf> {
-    // Special handling for OpenCode - use dynamic path resolution
-    if tool.key == "opencode" {
-        return crate::coding::mcp::opencode_path::get_opencode_mcp_config_path_sync();
-    }
+    select_preferred_mcp_config_path(resolve_mcp_config_paths(tool))
+}
 
-    // Use path_utils to resolve (handles ~/ and %APPDATA%/ paths)
-    tool.mcp_config_path
-        .as_ref()
-        .and_then(|path| resolve_storage_path(path))
+pub fn resolve_mcp_config_paths_with_db(
+    db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
+    tool: &RuntimeTool,
+) -> Vec<PathBuf> {
+    match tool.key.as_str() {
+        "opencode" | "claude_code" | "codex" => {
+            crate::coding::runtime_location::get_tool_mcp_config_path_sync(db, &tool.key)
+                .map(|path| vec![path])
+                .unwrap_or_else(|| resolve_mcp_config_paths(tool))
+        }
+        _ => resolve_mcp_config_paths(tool),
+    }
 }
 
 pub fn resolve_mcp_config_path_with_db(
     db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
     tool: &RuntimeTool,
 ) -> Option<PathBuf> {
+    select_preferred_mcp_config_path(resolve_mcp_config_paths_with_db(db, tool))
+}
+
+pub async fn resolve_mcp_config_paths_with_db_async(
+    db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
+    tool: &RuntimeTool,
+) -> Vec<PathBuf> {
     match tool.key.as_str() {
         "opencode" | "claude_code" | "codex" => {
-            crate::coding::runtime_location::get_tool_mcp_config_path_sync(db, &tool.key)
-                .or_else(|| resolve_mcp_config_path(tool))
+            crate::coding::runtime_location::get_tool_mcp_config_path_async(db, &tool.key)
+                .await
+                .map(|path| vec![path])
+                .unwrap_or_else(|| resolve_mcp_config_paths(tool))
         }
-        _ => resolve_mcp_config_path(tool),
+        _ => resolve_mcp_config_paths(tool),
     }
 }
 
@@ -80,14 +188,7 @@ pub async fn resolve_mcp_config_path_with_db_async(
     db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
     tool: &RuntimeTool,
 ) -> Option<PathBuf> {
-    match tool.key.as_str() {
-        "opencode" | "claude_code" | "codex" => {
-            crate::coding::runtime_location::get_tool_mcp_config_path_async(db, &tool.key)
-                .await
-                .or_else(|| resolve_mcp_config_path(tool))
-        }
-        _ => resolve_mcp_config_path(tool),
-    }
+    select_preferred_mcp_config_path(resolve_mcp_config_paths_with_db_async(db, tool).await)
 }
 
 pub fn resolve_skills_path_with_db(
@@ -228,9 +329,14 @@ pub fn get_installed_mcp_tools(custom_tools: &[CustomTool]) -> Vec<RuntimeTool> 
 
 /// Find a runtime tool by key
 pub fn runtime_tool_by_key(key: &str, custom_tools: &[CustomTool]) -> Option<RuntimeTool> {
+    let normalized_key = match key {
+        "github_copilot_intellij" => "github_copilot",
+        _ => key,
+    };
+
     get_all_runtime_tools(custom_tools)
         .into_iter()
-        .find(|t| t.key == key)
+        .find(|t| t.key == normalized_key)
 }
 
 /// Convert RuntimeTool to RuntimeToolDto with installation status
@@ -320,3 +426,73 @@ pub fn detect_all_tools(custom_tools: &[CustomTool]) -> Vec<ToolDetectionDto> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn github_copilot_runtime_tool() -> RuntimeTool {
+        RuntimeTool {
+            key: "github_copilot".to_string(),
+            display_name: "GitHub Copilot".to_string(),
+            is_custom: false,
+            relative_skills_dir: Some("~/.copilot/skills".to_string()),
+            relative_detect_dir: Some("%APPDATA%/Code".to_string()),
+            force_copy: false,
+            mcp_config_path: Some("%APPDATA%/Code/User/mcp.json".to_string()),
+            mcp_config_format: Some("json".to_string()),
+            mcp_field: Some("servers".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_resolve_mcp_config_paths_for_github_copilot_includes_vscode_and_intellij() {
+        let paths = resolve_mcp_config_paths(&github_copilot_runtime_tool());
+        let path_strings: Vec<String> = paths
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(path_strings.len(), 2);
+
+        #[cfg(windows)]
+        {
+            assert!(path_strings.iter().any(|path| path.ends_with("Code\\User\\mcp.json")));
+            let local_app_data = dirs::data_local_dir().unwrap();
+            let expected_intellij_path = local_app_data
+                .join("github-copilot")
+                .join("intellij")
+                .join("mcp.json")
+                .to_string_lossy()
+                .to_string();
+            assert!(path_strings.iter().any(|path| path == &expected_intellij_path));
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            assert!(path_strings
+                .iter()
+                .any(|path| path.ends_with("Code/User/mcp.json")));
+            assert!(path_strings.iter().any(|path| {
+                path.ends_with("Library/Application Support/GitHub Copilot/intellij/mcp.json")
+            }));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(path_strings
+                .iter()
+                .any(|path| path.ends_with("Code/User/mcp.json")));
+            assert!(path_strings
+                .iter()
+                .any(|path| path.ends_with("github-copilot/intellij/mcp.json")));
+        }
+    }
+
+    #[test]
+    fn test_runtime_tool_by_key_aliases_legacy_github_copilot_intellij_key() {
+        let tool = runtime_tool_by_key("github_copilot_intellij", &[]).unwrap();
+        assert_eq!(tool.key, "github_copilot");
+    }
+}
+

--- a/tauri/src/db_migration/mcp_github_copilot_key_v1.rs
+++ b/tauri/src/db_migration/mcp_github_copilot_key_v1.rs
@@ -1,0 +1,272 @@
+use std::collections::HashSet;
+
+use serde_json::{Map, Value};
+
+use crate::coding::{db_clean_id, db_record_id};
+use crate::db_migration::{
+    load_table_records, mark_migration_applied, migration_record_id, MigrationOutcome,
+};
+
+const MCP_SERVER_TABLE: &str = "mcp_server";
+const MCP_PREFERENCES_TABLE: &str = "mcp_preferences";
+pub const MIGRATION_ID: &str = "mcp_github_copilot_key_v1";
+
+fn normalize_tool_key(key: &str) -> &str {
+    match key {
+        "github_copilot_intellij" => "github_copilot",
+        _ => key,
+    }
+}
+
+fn normalize_tool_list(value: &Value) -> Option<Vec<String>> {
+    let arr = value.as_array()?;
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for item in arr {
+        let Some(key) = item.as_str() else {
+            continue;
+        };
+        let normalized_key = normalize_tool_key(key).to_string();
+        if seen.insert(normalized_key.clone()) {
+            normalized.push(normalized_key);
+        }
+    }
+
+    Some(normalized)
+}
+
+fn merge_sync_detail_values(existing: &mut Value, incoming: &Value) {
+    let Some(existing_obj) = existing.as_object_mut() else {
+        return;
+    };
+    let Some(incoming_obj) = incoming.as_object() else {
+        return;
+    };
+
+    for (key, value) in incoming_obj {
+        let should_insert = existing_obj
+            .get(key)
+            .map(|existing_value| existing_value.is_null())
+            .unwrap_or(true);
+        if should_insert {
+            existing_obj.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn is_canonical_tool_key(tool_key: &str, normalized_key: &str) -> bool {
+    tool_key == normalized_key
+}
+
+fn normalize_sync_details_value(value: &Value) -> Option<Value> {
+    let obj = value.as_object()?;
+    let mut normalized = Map::new();
+
+    for (tool_key, detail) in obj {
+        let normalized_key = normalize_tool_key(tool_key).to_string();
+        if let Some(existing) = normalized.get_mut(&normalized_key) {
+            if is_canonical_tool_key(tool_key, &normalized_key) {
+                let mut canonical_detail = detail.clone();
+                merge_sync_detail_values(&mut canonical_detail, existing);
+                *existing = canonical_detail;
+            } else {
+                merge_sync_detail_values(existing, detail);
+            }
+        } else {
+            normalized.insert(normalized_key, detail.clone());
+        }
+    }
+
+    Some(Value::Object(normalized))
+}
+
+fn normalize_mcp_server_payload(record: &Value) -> Result<Option<Value>, String> {
+    let record_id = record
+        .get("id")
+        .and_then(|value| value.as_str())
+        .map(db_clean_id)
+        .ok_or_else(|| "Failed to extract MCP server record id during migration".to_string())?;
+
+    let mut payload = record.clone();
+    let payload_obj = payload
+        .as_object_mut()
+        .ok_or_else(|| format!("Expected object payload for {}:{}", MCP_SERVER_TABLE, record_id))?;
+    payload_obj.remove("id");
+
+    let mut changed = false;
+
+    if let Some(enabled_tools_value) = payload_obj.get("enabled_tools") {
+        if let Some(normalized) = normalize_tool_list(enabled_tools_value) {
+            let new_value = serde_json::json!(normalized);
+            if new_value != *enabled_tools_value {
+                payload_obj.insert("enabled_tools".to_string(), new_value);
+                changed = true;
+            }
+        }
+    }
+
+    if let Some(sync_details_value) = payload_obj.get("sync_details") {
+        if let Some(normalized) = normalize_sync_details_value(sync_details_value) {
+            if normalized != *sync_details_value {
+                payload_obj.insert("sync_details".to_string(), normalized);
+                changed = true;
+            }
+        }
+    }
+
+    Ok(changed.then_some(payload))
+}
+
+fn normalize_mcp_preferences_payload(record: &Value) -> Result<Option<Value>, String> {
+    let record_id = record
+        .get("id")
+        .and_then(|value| value.as_str())
+        .map(db_clean_id)
+        .ok_or_else(|| "Failed to extract MCP preferences record id during migration".to_string())?;
+
+    let mut payload = record.clone();
+    let payload_obj = payload.as_object_mut().ok_or_else(|| {
+        format!(
+            "Expected object payload for {}:{}",
+            MCP_PREFERENCES_TABLE, record_id
+        )
+    })?;
+    payload_obj.remove("id");
+
+    let mut changed = false;
+
+    if let Some(preferred_tools_value) = payload_obj.get("preferred_tools") {
+        if let Some(normalized) = normalize_tool_list(preferred_tools_value) {
+            let new_value = serde_json::json!(normalized);
+            if new_value != *preferred_tools_value {
+                payload_obj.insert("preferred_tools".to_string(), new_value);
+                changed = true;
+            }
+        }
+    }
+
+    Ok(changed.then_some(payload))
+}
+
+fn build_update_statement(table_name: &str, record_id: &str, payload: &Value) -> Result<String, String> {
+    let payload_json = serde_json::to_string(payload).map_err(|error| {
+        format!(
+            "Failed to serialize migration payload for {}:{}: {}",
+            table_name, record_id, error
+        )
+    })?;
+
+    Ok(format!(
+        "UPDATE {} CONTENT {}",
+        db_record_id(table_name, record_id),
+        payload_json
+    ))
+}
+
+pub fn run_migration(
+    db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<MigrationOutcome, String>> + Send + '_>> {
+    Box::pin(async move {
+        let mcp_server_records = load_table_records(db, MCP_SERVER_TABLE).await?;
+        let mcp_preferences_records = load_table_records(db, MCP_PREFERENCES_TABLE).await?;
+
+        let mut statements = Vec::new();
+
+        for record in &mcp_server_records {
+            let record_id = record
+                .get("id")
+                .and_then(|value| value.as_str())
+                .map(db_clean_id)
+                .ok_or_else(|| {
+                    "Failed to extract MCP server record id when preparing migration".to_string()
+                })?;
+
+            if let Some(payload) = normalize_mcp_server_payload(record)? {
+                statements.push(build_update_statement(MCP_SERVER_TABLE, &record_id, &payload)?);
+            }
+        }
+
+        for record in &mcp_preferences_records {
+            let record_id = record
+                .get("id")
+                .and_then(|value| value.as_str())
+                .map(db_clean_id)
+                .ok_or_else(|| {
+                    "Failed to extract MCP preferences record id when preparing migration"
+                        .to_string()
+                })?;
+
+            if let Some(payload) = normalize_mcp_preferences_payload(record)? {
+                statements.push(build_update_statement(
+                    MCP_PREFERENCES_TABLE,
+                    &record_id,
+                    &payload,
+                )?);
+            }
+        }
+
+        if statements.is_empty() {
+            mark_migration_applied(db, MIGRATION_ID, "skipped_noop").await?;
+            return Ok(MigrationOutcome::SkippedNoOp);
+        }
+
+        let mut transaction = String::from("BEGIN TRANSACTION;\n");
+        for statement in &statements {
+            transaction.push_str(statement);
+            transaction.push_str(";\n");
+        }
+        transaction.push_str(&format!(
+            "UPSERT {} CONTENT {{ migration_id: '{}', status: 'applied', applied_at: time::now() }};\n",
+            migration_record_id(MIGRATION_ID),
+            MIGRATION_ID
+        ));
+        transaction.push_str("COMMIT TRANSACTION;");
+
+        db.query(transaction).await.map_err(|error| {
+            format!(
+                "Failed to apply database migration '{}': {}",
+                MIGRATION_ID, error
+            )
+        })?;
+
+        Ok(MigrationOutcome::Applied)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_normalize_tool_list_dedupes_legacy_github_copilot_key() {
+        let value = json!(["github_copilot_intellij", "github_copilot", "codex"]);
+        let normalized = normalize_tool_list(&value).unwrap();
+        assert_eq!(normalized, vec!["github_copilot", "codex"]);
+    }
+
+    #[test]
+    fn test_normalize_sync_details_value_merges_legacy_key_into_canonical() {
+        let value = json!({
+            "github_copilot_intellij": {
+                "status": "ok",
+                "synced_at": 1,
+                "error_message": null
+            },
+            "github_copilot": {
+                "status": "pending"
+            }
+        });
+
+        let normalized = normalize_sync_details_value(&value).unwrap();
+        assert!(normalized.get("github_copilot_intellij").is_none());
+        assert_eq!(normalized["github_copilot"]["status"], "pending");
+        assert_eq!(normalized["github_copilot"]["synced_at"], 1);
+        assert!(normalized["github_copilot"]["error_message"].is_null());
+    }
+}
+
+
+

--- a/tauri/src/db_migration/mod.rs
+++ b/tauri/src/db_migration/mod.rs
@@ -1,3 +1,4 @@
+mod mcp_github_copilot_key_v1;
 mod oh_my_openagent_rename_v1;
 
 use serde_json::Value;
@@ -19,11 +20,18 @@ struct DbMigration {
     runner: MigrationRunner,
 }
 
-const REGISTERED_MIGRATIONS: &[DbMigration] = &[DbMigration {
-    id: oh_my_openagent_rename_v1::MIGRATION_ID,
-    description: "Rename Oh My OpenAgent main persistence contracts",
-    runner: oh_my_openagent_rename_v1::run_migration,
-}];
+const REGISTERED_MIGRATIONS: &[DbMigration] = &[
+    DbMigration {
+        id: oh_my_openagent_rename_v1::MIGRATION_ID,
+        description: "Rename Oh My OpenAgent main persistence contracts",
+        runner: oh_my_openagent_rename_v1::run_migration,
+    },
+    DbMigration {
+        id: mcp_github_copilot_key_v1::MIGRATION_ID,
+        description: "Normalize MCP GitHub Copilot legacy IntelliJ tool keys",
+        runner: mcp_github_copilot_key_v1::run_migration,
+    },
+];
 
 /// Execute all registered database migrations in order.
 ///


### PR DESCRIPTION
This pull request significantly improves support for GitHub Copilot MCP sync by introducing multi-location handling (for both VSCode and IntelliJ plugin config paths), deduplication and merging of imported servers, and normalization of tool keys throughout the codebase. It also adds robust error handling and test coverage for these new behaviors.

**GitHub Copilot multi-location sync and import:**
* Added logic to detect, sync, and import MCP servers across all known GitHub Copilot plugin config locations (VSCode and IntelliJ), including helper functions for path resolution and labeling. This ensures that both plugin environments are kept in sync and avoids duplicate server entries. [[1]](diffhunk://#diff-464f6e5c762e8a7ebb84041f2b4561b7c6ce7b6898f5d73695a9e9ded0023facR11-R117) [[2]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcL7-R74) [[3]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR99-R123) [[4]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR135-R160) [[5]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR173-R192) [[6]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR203-R222) [[7]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR758-R770) [[8]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR780-R792) [[9]](diffhunk://#diff-3ec9f9ae78cb1058cf5dbcb1b32b2499bbd368bd7ce829ee3ce8a80f4de54d47L122-R123)
* When importing servers from multiple config files, identical servers are deduplicated and conflicting names are suffixed with their source (e.g., "demo (IntelliJ)"). [[1]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcL7-R74) [[2]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR758-R770) [[3]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR780-R792)

**Tool key normalization and compatibility:**
* Introduced a `normalize_tool_key` function to consistently treat `github_copilot_intellij` as `github_copilot` throughout the codebase, ensuring compatibility and correct grouping of related tools. [[1]](diffhunk://#diff-7162bfb619555729bf8bfafe480c215f5b16048766e760f47f8653ea222912b0R10-R24) [[2]](diffhunk://#diff-7162bfb619555729bf8bfafe480c215f5b16048766e760f47f8653ea222912b0L101-R108) [[3]](diffhunk://#diff-7162bfb619555729bf8bfafe480c215f5b16048766e760f47f8653ea222912b0L172-R179) [[4]](diffhunk://#diff-3ec9f9ae78cb1058cf5dbcb1b32b2499bbd368bd7ce829ee3ce8a80f4de54d47L187-R193)

**Error handling and robustness:**
* Enhanced error aggregation for multi-path sync and removal operations, so failures in one location do not prevent others from succeeding, and all errors are reported together. [[1]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR99-R123) [[2]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR135-R160) [[3]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR173-R192) [[4]](diffhunk://#diff-4212e6a6e232904df64bf266c13d4a24fa600a533141772d15c469763d0a73fcR203-R222)

**Testing:**
* Added unit tests to verify deduplication and name conflict resolution when merging imported servers from multiple GitHub Copilot plugin locations.

**Generalization and refactoring:**
* Refactored config path resolution to allow tools to provide multiple MCP config paths, and updated detection logic to use these new helpers. [[1]](diffhunk://#diff-464f6e5c762e8a7ebb84041f2b4561b7c6ce7b6898f5d73695a9e9ded0023facR11-R117) [[2]](diffhunk://#diff-464f6e5c762e8a7ebb84041f2b4561b7c6ce7b6898f5d73695a9e9ded0023facL33-L34) [[3]](diffhunk://#diff-6be7d1b7a248afc5512f36a6282bf991035019b63098d90273b3f2185689e771L21-R22) [[4]](diffhunk://#diff-6be7d1b7a248afc5512f36a6282bf991035019b63098d90273b3f2185689e771L665-R688) [[5]](diffhunk://#diff-6be7d1b7a248afc5512f36a6282bf991035019b63098d90273b3f2185689e771R707-R716)