### PR TITLE
fix: preserve marketplace auto-update settings across CLI operations

### DIFF
--- a/tauri/src/coding/claude_code/commands.rs
+++ b/tauri/src/coding/claude_code/commands.rs
@@ -1715,11 +1715,19 @@ pub async fn add_claude_marketplace(
 ) -> Result<(), String> {
     let db = state.db();
     let runtime_location = runtime_location::get_claude_runtime_location_async(&db).await?;
+    // Backup auto-update settings before CLI rewrites known_marketplaces.json
+    let auto_update_backup =
+        plugin_state::backup_marketplace_auto_update_settings(&runtime_location.host_path)?;
     plugin_cli::run_claude_plugin_command(
         &runtime_location,
         &["plugin", "marketplace", "add", &input.source],
     )
     .await?;
+    // Restore auto-update settings that may have been lost
+    plugin_state::restore_marketplace_auto_update_settings(
+        &runtime_location.host_path,
+        &auto_update_backup,
+    )?;
     emit_claude_plugin_config_changed(&app);
     Ok(())
 }
@@ -1732,11 +1740,19 @@ pub async fn update_claude_marketplace(
 ) -> Result<(), String> {
     let db = state.db();
     let runtime_location = runtime_location::get_claude_runtime_location_async(&db).await?;
+    // Backup auto-update settings before CLI rewrites known_marketplaces.json
+    let auto_update_backup =
+        plugin_state::backup_marketplace_auto_update_settings(&runtime_location.host_path)?;
     let mut args = vec!["plugin", "marketplace", "update"];
     if let Some(marketplace_name) = input.marketplace_name.as_deref() {
         args.push(marketplace_name);
     }
     plugin_cli::run_claude_plugin_command(&runtime_location, &args).await?;
+    // Restore auto-update settings that may have been lost
+    plugin_state::restore_marketplace_auto_update_settings(
+        &runtime_location.host_path,
+        &auto_update_backup,
+    )?;
     emit_claude_plugin_config_changed(&app);
     Ok(())
 }
@@ -1766,11 +1782,19 @@ pub async fn remove_claude_marketplace(
 ) -> Result<(), String> {
     let db = state.db();
     let runtime_location = runtime_location::get_claude_runtime_location_async(&db).await?;
+    // Backup auto-update settings before CLI rewrites known_marketplaces.json
+    let auto_update_backup =
+        plugin_state::backup_marketplace_auto_update_settings(&runtime_location.host_path)?;
     plugin_cli::run_claude_plugin_command(
         &runtime_location,
         &["plugin", "marketplace", "remove", &input.marketplace_name],
     )
     .await?;
+    // Restore auto-update settings that may have been lost
+    plugin_state::restore_marketplace_auto_update_settings(
+        &runtime_location.host_path,
+        &auto_update_backup,
+    )?;
     emit_claude_plugin_config_changed(&app);
     Ok(())
 }

--- a/tauri/src/coding/claude_code/plugin_state.rs
+++ b/tauri/src/coding/claude_code/plugin_state.rs
@@ -281,6 +281,54 @@ pub async fn list_claude_known_marketplaces(
     Ok(marketplaces)
 }
 
+/// Backup auto_update_enabled settings for all known marketplaces.
+/// Used to preserve these settings before calling external CLI commands
+/// that may rewrite known_marketplaces.json without this field.
+pub fn backup_marketplace_auto_update_settings(
+    host_path: &Path,
+) -> Result<HashMap<String, bool>, String> {
+    let known_marketplaces_file_path = known_marketplaces_path(host_path);
+    let marketplaces_file: HashMap<String, KnownMarketplaceEntry> =
+        read_json_file_or_default(&known_marketplaces_file_path)?;
+
+    let mut settings = HashMap::new();
+    for (name, entry) in &marketplaces_file {
+        if let Some(enabled) = entry.auto_update_enabled {
+            settings.insert(name.clone(), enabled);
+        }
+    }
+    Ok(settings)
+}
+
+/// Restore auto_update_enabled settings after external CLI commands
+/// have potentially rewritten known_marketplaces.json.
+pub fn restore_marketplace_auto_update_settings(
+    host_path: &Path,
+    settings: &HashMap<String, bool>,
+) -> Result<(), String> {
+    if settings.is_empty() {
+        return Ok(());
+    }
+    let known_marketplaces_file_path = known_marketplaces_path(host_path);
+    let mut marketplaces_file: HashMap<String, KnownMarketplaceEntry> =
+        read_json_file_or_default(&known_marketplaces_file_path)?;
+
+    let mut changed = false;
+    for (name, enabled) in settings {
+        if let Some(entry) = marketplaces_file.get_mut(name) {
+            if entry.auto_update_enabled != Some(*enabled) {
+                entry.auto_update_enabled = Some(*enabled);
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        write_json_file_pretty(&known_marketplaces_file_path, &marketplaces_file)?;
+    }
+    Ok(())
+}
+
 pub async fn set_claude_marketplace_auto_update_enabled(
     db: &surrealdb::Surreal<surrealdb::engine::local::Db>,
     marketplace_name: &str,


### PR DESCRIPTION
## 问题描述

通过 UI 添加、更新或删除 marketplace 时，外部 `claude` CLI 会重写 `known_marketplaces.json`，但不会保留 `autoUpdateEnabled` 字段。这导致所有已配置的自动更新设置被重置为关闭状态。

## 根因分析

`claude` CLI 在修改 `known_marketplaces.json` 时只写入它自身管理的字段（`source`、`installLocation`、`lastUpdated`）。`autoUpdateEnabled` 字段是 ai-toolbox 独有的，CLI 不认识这个字段，重写后直接丢失。反序列化时 `#[serde(default)]` 将缺失字段设为 `None`，显示为 `false`。

## 修复方案

- **`plugin_state.rs`**：新增 `backup_marketplace_auto_update_settings()` 和 `restore_marketplace_auto_update_settings()` 两个辅助函数
- **`commands.rs`**：在 `add_claude_marketplace`、`update_claude_marketplace`、`remove_claude_marketplace` 三个调用外部 CLI 的命令中，执行前备份自动更新设置，执行后恢复。仅在设置实际发生变化时才写回文件，避免不必要的 I/O

## 测试计划

- [ ] 为一个或多个 marketplace 开启自动更新
- [ ] 添加新 marketplace → 验证已有的自动更新设置未被改变
- [ ] 更新 marketplace → 验证自动更新设置未被改变
- [ ] 删除 marketplace → 验证剩余 marketplace 的自动更新设置未被改变
- [ ] 验证新添加的 marketplace 默认自动更新为关闭（无副作用）