### PR TITLE
fix(opencode): support experimental model modes

### DIFF
--- a/tauri/src/coding/open_code/AGENTS.md
+++ b/tauri/src/coding/open_code/AGENTS.md
@@ -9,6 +9,7 @@
 - 当前生效配置文件路径的优先级是：应用内 `common_config.config_path` > 环境变量 `OPENCODE_CONFIG` > shell 配置 > 默认路径。
 - OpenCode prompt 文件不是独立根目录配置，而是基于当前生效配置文件所在目录派生出的 `AGENTS.md`。
 - OpenCode 主模型和小模型的运行时值都使用 `provider_id/model_id` 格式；不要把它降成裸 `model_id`。
+- models.dev 的 `experimental.modes.*` 在 OpenCode 语义中会展开成虚拟模型，ID 形如 `${base_model_id}-${mode}`，例如 `gpt-5.5-fast`；后端统一模型列表需要透出 `base_model_id` / `experimental_mode`，供前端继承 base variants。
 - `favorite provider` / `我使用过的供应商` 库不是当前配置镜像，而是独立的历史库和诊断缓存；真正的 OpenCode 运行时配置仍以当前配置文件内容为准。
 
 ## 核心设计决策（Why）
@@ -43,6 +44,8 @@ sequenceDiagram
 - 不要把 OpenCode prompt 路径写死成 `~/.config/opencode/AGENTS.md`。应始终先走当前配置路径决议，再取同目录下的 `AGENTS.md`。
 - 前端显示的 `configPathInfo.source` 只是“路径来自哪里”，不是 WSL Direct 判断。WSL Direct 统一看 `runtime_location` / `module_statuses`。
 - 不要把 OpenCode 的模型值只当成 `model_id`。tray、统一模型列表和配置文件都约定使用 `provider_id/model_id`，少一段就会导致选中态和写回都失真。
+- `provider_id/model_id` 只能按第一个 `/` 分隔；models.dev 里有些 model id 自身包含 `/`，例如 `zenmux/openai/gpt-5.5-fast` 的 provider 是 `zenmux`，model id 是 `openai/gpt-5.5-fast`。托盘和保存逻辑不能用 `split('/')` 后要求两段。
+- 展开 `experimental.modes.*` 时要避免和真实 `${base_model_id}-${mode}` 模型重复；真实模型优先，虚拟模型跳过。
 - tray 展示模型时会把当前已选模型保留在菜单里，即使其 provider 已被禁用；改 tray 过滤逻辑时不要把当前选择无提示隐藏掉。
 - prompt tray 会过滤掉 `__local__` 临时项。页面仍可能把当前本地文件映射成 `__local__` 且视为已应用，因此页面与 tray 对“当前应用 prompt”的表达不一定完全对称。
 - `favorite provider` 库的产品语义是“使用过的供应商历史库”，主要用于删除后找回和保留诊断信息；如果某个 provider 已不在当前配置里但仍留在库中，默认先视为预期语义，而不是脏数据。

--- a/tauri/src/coding/open_code/free_models.rs
+++ b/tauri/src/coding/open_code/free_models.rs
@@ -18,6 +18,7 @@ const DEFAULT_MODELS_JSON: &str = include_str!("../../../resources/models.dev.js
 const MODELS_API_URL: &str = "https://models.dev/api.json";
 const CACHE_FILE_NAME: &str = "models.dev.json";
 const OPENCODE_PROVIDER_ID: &str = "opencode";
+const MODEL_STATUS_DEPRECATED: &str = "deprecated";
 const CACHE_DURATION_HOURS: u64 = 6;
 const MIN_REFRESH_INTERVAL_SECS: u64 = 30;
 
@@ -267,46 +268,124 @@ fn filter_free_models(provider_id: &str, provider_data: &serde_json::Value) -> V
         None => return free_models,
     };
 
-    for (model_id, model_obj) in models_obj {
-        if let Some(model) = model_obj.as_object() {
-            let is_free = model
-                .get("cost")
-                .and_then(|cost| cost.as_object())
-                .map(|cost| {
-                    let input = cost.get("input").and_then(|v| v.as_f64()).unwrap_or(-1.0);
-                    let output = cost.get("output").and_then(|v| v.as_f64()).unwrap_or(-1.0);
-                    input == 0.0 && output == 0.0
-                })
-                .unwrap_or(false);
-
-            if is_free {
-                let status = model.get("status").and_then(|v| v.as_str());
-                if status == Some("deprecated") {
-                    continue;
-                }
-
-                let model_name = model
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or(model_id)
-                    .to_string();
-
+    for_each_active_model_with_modes(
+        models_obj,
+        |model_id, model_name, model_obj, base_model_id, experimental_mode, mode_obj| {
+            if is_model_free_with_mode(model_obj, mode_obj) {
                 free_models.push(FreeModel {
-                    id: model_id.clone(),
+                    id: model_id,
                     name: model_name,
                     provider_id: provider_id.to_string(),
                     provider_name: provider_name.clone(),
-                    context: model
-                        .get("limit")
-                        .and_then(|limit| limit.as_object())
-                        .and_then(|limit| limit.get("context"))
-                        .and_then(|v| v.as_i64()),
+                    context: model_context_limit(model_obj),
+                    base_model_id,
+                    experimental_mode,
                 });
             }
-        }
-    }
+        },
+    );
 
     free_models
+}
+
+fn model_name_from_value(model_id: &str, model_obj: &serde_json::Value) -> String {
+    model_obj
+        .get("name")
+        .and_then(|value| value.as_str())
+        .unwrap_or(model_id)
+        .to_string()
+}
+
+fn model_status(model_obj: &serde_json::Value) -> Option<&str> {
+    model_obj.get("status").and_then(|value| value.as_str())
+}
+
+fn model_context_limit(model_obj: &serde_json::Value) -> Option<i64> {
+    model_obj
+        .get("limit")
+        .and_then(|limit| limit.as_object())
+        .and_then(|limit| limit.get("context"))
+        .and_then(|value| value.as_i64())
+}
+
+fn model_output_limit(model_obj: &serde_json::Value) -> Option<i64> {
+    model_obj
+        .get("limit")
+        .and_then(|limit| limit.as_object())
+        .and_then(|limit| limit.get("output"))
+        .and_then(|value| value.as_i64())
+}
+
+fn format_experimental_mode_name(mode: &str) -> String {
+    let mut chars = mode.chars();
+    match chars.next() {
+        Some(first) => {
+            let mut result = String::new();
+            result.extend(first.to_uppercase());
+            result.push_str(chars.as_str());
+            result
+        }
+        None => mode.to_string(),
+    }
+}
+
+fn for_each_active_model_with_modes<F>(
+    models_obj: &serde_json::Map<String, serde_json::Value>,
+    mut visit: F,
+) where
+    F: FnMut(
+        String,
+        String,
+        &serde_json::Value,
+        Option<String>,
+        Option<String>,
+        Option<&serde_json::Value>,
+    ),
+{
+    for (model_id, model_obj) in models_obj {
+        if model_status(model_obj) == Some(MODEL_STATUS_DEPRECATED) {
+            continue;
+        }
+
+        let model_name = model_name_from_value(model_id, model_obj);
+        visit(
+            model_id.clone(),
+            model_name.clone(),
+            model_obj,
+            None,
+            None,
+            None,
+        );
+
+        let Some(modes_obj) = model_obj
+            .get("experimental")
+            .and_then(|experimental| experimental.get("modes"))
+            .and_then(|modes| modes.as_object())
+        else {
+            continue;
+        };
+
+        for (mode, mode_obj) in modes_obj {
+            let virtual_model_id = format!("{}-{}", model_id, mode);
+            if models_obj.contains_key(&virtual_model_id) {
+                continue;
+            }
+
+            let mode_status = mode_obj.get("status").and_then(|value| value.as_str());
+            if mode_status == Some(MODEL_STATUS_DEPRECATED) {
+                continue;
+            }
+
+            visit(
+                virtual_model_id,
+                format!("{} {}", model_name, format_experimental_mode_name(mode)),
+                model_obj,
+                Some(model_id.clone()),
+                Some(mode.clone()),
+                Some(mode_obj),
+            );
+        }
+    }
 }
 
 fn is_cache_expired(updated_at: &str) -> bool {
@@ -632,16 +711,78 @@ pub fn get_resolved_auth_provider_ids() -> Vec<String> {
 // Unified Models API
 // ============================================================================
 
-fn is_model_free_from_value(model_obj: &serde_json::Value) -> bool {
-    model_obj
-        .get("cost")
-        .and_then(|cost| cost.as_object())
-        .map(|cost| {
-            let input = cost.get("input").and_then(|v| v.as_f64()).unwrap_or(-1.0);
-            let output = cost.get("output").and_then(|v| v.as_f64()).unwrap_or(-1.0);
-            input == 0.0 && output == 0.0
-        })
-        .unwrap_or(false)
+fn is_model_free_with_mode(
+    model_obj: &serde_json::Value,
+    mode_obj: Option<&serde_json::Value>,
+) -> bool {
+    let base_cost = model_obj.get("cost").and_then(|cost| cost.as_object());
+    let mode_cost = mode_obj
+        .and_then(|mode| mode.get("cost"))
+        .and_then(|cost| cost.as_object());
+
+    let cost_value = |key: &str| {
+        mode_cost
+            .and_then(|cost| cost.get(key))
+            .or_else(|| base_cost.and_then(|cost| cost.get(key)))
+            .and_then(|value| value.as_f64())
+            .unwrap_or(-1.0)
+    };
+
+    cost_value("input") == 0.0 && cost_value("output") == 0.0
+}
+
+fn push_unified_model_option(
+    provider_models: &mut Vec<UnifiedModelOption>,
+    provider_id: &str,
+    provider_name: &str,
+    model_id: String,
+    model_name: String,
+    base_model_id: Option<String>,
+    experimental_mode: Option<String>,
+    model_obj: &serde_json::Value,
+    mode_obj: Option<&serde_json::Value>,
+) {
+    let is_free = is_model_free_with_mode(model_obj, mode_obj);
+    let display_name = if provider_id == OPENCODE_PROVIDER_ID && is_free {
+        format!("{} / {} (Free)", provider_name, model_name)
+    } else {
+        format!("{} / {}", provider_name, model_name)
+    };
+
+    provider_models.push(UnifiedModelOption {
+        id: format!("{}/{}", provider_id, model_id),
+        display_name,
+        provider_id: provider_id.to_string(),
+        model_id,
+        is_free,
+        base_model_id,
+        experimental_mode,
+    });
+}
+
+fn push_official_model_option(
+    official_models_list: &mut Vec<OfficialModel>,
+    provider_id: &str,
+    model_id: String,
+    model_name: String,
+    model_obj: &serde_json::Value,
+    mode_obj: Option<&serde_json::Value>,
+) {
+    let status = mode_obj
+        .and_then(|mode| mode.get("status"))
+        .and_then(|value| value.as_str())
+        .or_else(|| model_status(model_obj))
+        .map(String::from);
+
+    official_models_list.push(OfficialModel {
+        id: model_id,
+        name: model_name,
+        context: model_context_limit(model_obj),
+        output: model_output_limit(model_obj),
+        is_free: provider_id == OPENCODE_PROVIDER_ID
+            && is_model_free_with_mode(model_obj, mode_obj),
+        status,
+    });
 }
 
 fn apply_model_filters(
@@ -681,11 +822,11 @@ pub async fn get_unified_models(
 ) -> Vec<UnifiedModelOption> {
     let mut models: Vec<UnifiedModelOption> = Vec::new();
 
-    let has_opencode_auth = auth_channels.contains(&"opencode".to_string());
+    let has_opencode_auth = auth_channels.contains(&OPENCODE_PROVIDER_ID.to_string());
     let mut official_provider_ids = auth_channels.to_vec();
 
     if !has_opencode_auth {
-        official_provider_ids.retain(|id| id != "opencode");
+        official_provider_ids.retain(|id| id != OPENCODE_PROVIDER_ID);
     }
 
     let mut official_models = read_providers_batch(&official_provider_ids);
@@ -714,6 +855,8 @@ pub async fn get_unified_models(
                     provider_id: provider_id.clone(),
                     model_id: model_id.clone(),
                     is_free: false,
+                    base_model_id: None,
+                    experimental_mode: None,
                 });
             }
 
@@ -725,38 +868,33 @@ pub async fn get_unified_models(
                     .get("models")
                     .and_then(|m| m.as_object())
                 {
-                    for (model_id, model_obj) in models_obj {
-                        let full_id = format!("{}/{}", provider_id, model_id);
+                    for_each_active_model_with_modes(
+                        models_obj,
+                        |model_id,
+                         model_name,
+                         model_obj,
+                         base_model_id,
+                         experimental_mode,
+                         mode_obj| {
+                            let full_id = format!("{}/{}", provider_id, model_id);
 
-                        if custom_model_ids.contains(&full_id) {
-                            continue;
-                        }
+                            if custom_model_ids.contains(&full_id) {
+                                return;
+                            }
 
-                        let status = model_obj.get("status").and_then(|v| v.as_str());
-                        if status == Some("deprecated") {
-                            continue;
-                        }
-
-                        let model_name = model_obj
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or(model_id);
-                        let is_free = is_model_free_from_value(model_obj);
-
-                        let display_name = if provider_id == "opencode" && is_free {
-                            format!("{} / {} (Free)", provider_name, model_name)
-                        } else {
-                            format!("{} / {}", provider_name, model_name)
-                        };
-
-                        provider_models.push(UnifiedModelOption {
-                            id: full_id,
-                            display_name,
-                            provider_id: provider_id.clone(),
-                            model_id: model_id.clone(),
-                            is_free,
-                        });
-                    }
+                            push_unified_model_option(
+                                &mut provider_models,
+                                provider_id,
+                                provider_name,
+                                model_id,
+                                model_name,
+                                base_model_id,
+                                experimental_mode,
+                                model_obj,
+                                mode_obj,
+                            );
+                        },
+                    );
                 }
             }
 
@@ -784,32 +922,22 @@ pub async fn get_unified_models(
             .get("models")
             .and_then(|m| m.as_object())
         {
-            for (model_id, model_obj) in models_obj {
-                let status = model_obj.get("status").and_then(|v| v.as_str());
-                if status == Some("deprecated") {
-                    continue;
-                }
-
-                let model_name = model_obj
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .unwrap_or(model_id);
-                let is_free = is_model_free_from_value(model_obj);
-
-                let display_name = if provider_id == "opencode" && is_free {
-                    format!("{} / {} (Free)", provider_name, model_name)
-                } else {
-                    format!("{} / {}", provider_name, model_name)
-                };
-
-                provider_models.push(UnifiedModelOption {
-                    id: format!("{}/{}", provider_id, model_id),
-                    display_name,
-                    provider_id: provider_id.clone(),
-                    model_id: model_id.clone(),
-                    is_free,
-                });
-            }
+            for_each_active_model_with_modes(
+                models_obj,
+                |model_id, model_name, model_obj, base_model_id, experimental_mode, mode_obj| {
+                    push_unified_model_option(
+                        &mut provider_models,
+                        provider_id,
+                        provider_name,
+                        model_id,
+                        model_name,
+                        base_model_id,
+                        experimental_mode,
+                        model_obj,
+                        mode_obj,
+                    );
+                },
+            );
         }
 
         provider_models.sort_by(|a, b| a.display_name.cmp(&b.display_name));
@@ -831,6 +959,8 @@ pub async fn get_unified_models(
                         provider_id: free_model.provider_id,
                         model_id: free_model.id,
                         is_free: true,
+                        base_model_id: free_model.base_model_id,
+                        experimental_mode: free_model.experimental_mode,
                     });
                 }
                 free_vec.sort_by(|a, b| a.display_name.cmp(&b.display_name));
@@ -871,7 +1001,7 @@ pub async fn get_auth_providers_data(
 
     let official_provider_ids: Vec<String> = auth_channels
         .into_iter()
-        .filter(|id| id != "opencode")
+        .filter(|id| id != OPENCODE_PROVIDER_ID)
         .collect();
 
     let mut official_models = read_providers_batch(&official_provider_ids);
@@ -899,56 +1029,25 @@ pub async fn get_auth_providers_data(
             .get("models")
             .and_then(|m| m.as_object())
         {
-            for (model_id, model_obj) in models_obj {
-                let full_id = format!("{}/{}", provider_id, model_id);
+            for_each_active_model_with_modes(
+                models_obj,
+                |model_id, model_name, model_obj, _base_model_id, _experimental_mode, mode_obj| {
+                    let full_id = format!("{}/{}", provider_id, model_id);
 
-                if custom_model_ids.contains(&full_id) {
-                    continue;
-                }
+                    if custom_model_ids.contains(&full_id) {
+                        return;
+                    }
 
-                let status = model_obj.get("status").and_then(|v| v.as_str());
-                if status == Some("deprecated") {
-                    continue;
-                }
-
-                let model_name = model_obj
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .unwrap_or(model_id)
-                    .to_string();
-
-                let context = model_obj
-                    .get("limit")
-                    .and_then(|limit| limit.as_object())
-                    .and_then(|limit| limit.get("context"))
-                    .and_then(|v| v.as_i64());
-
-                let output = model_obj
-                    .get("limit")
-                    .and_then(|limit| limit.as_object())
-                    .and_then(|limit| limit.get("output"))
-                    .and_then(|v| v.as_i64());
-
-                let is_free = if provider_id == "opencode" {
-                    is_model_free_from_value(model_obj)
-                } else {
-                    false
-                };
-
-                let status = model_obj
-                    .get("status")
-                    .and_then(|v| v.as_str())
-                    .map(String::from);
-
-                official_models_list.push(OfficialModel {
-                    id: model_id.to_string(),
-                    name: model_name,
-                    context,
-                    output,
-                    is_free,
-                    status,
-                });
-            }
+                    push_official_model_option(
+                        &mut official_models_list,
+                        provider_id,
+                        model_id,
+                        model_name,
+                        model_obj,
+                        mode_obj,
+                    );
+                },
+            );
         }
 
         official_models_list.sort_by(|a, b| a.name.cmp(&b.name));
@@ -973,5 +1072,288 @@ pub async fn get_auth_providers_data(
         merged_models,
         resolved_auth_provider_ids,
         custom_provider_ids,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn collect_model_ids_and_names(provider_data: &serde_json::Value) -> Vec<(String, String)> {
+        let models_obj = provider_data
+            .get("models")
+            .and_then(|models| models.as_object())
+            .expect("models object");
+
+        let mut collected = Vec::new();
+        for_each_active_model_with_modes(models_obj, |model_id, model_name, _, _, _, _| {
+            collected.push((model_id, model_name));
+        });
+
+        collected
+    }
+
+    #[test]
+    fn experimental_modes_expand_to_virtual_models() {
+        let provider_data = json!({
+            "name": "OpenCode Zen",
+            "models": {
+                "gpt-5.5": {
+                    "name": "GPT-5.5",
+                    "status": "active",
+                    "cost": {
+                        "input": 5.0,
+                        "output": 30.0,
+                        "cache_read": 0.5
+                    },
+                    "limit": {
+                        "context": 1_050_000,
+                        "output": 128_000
+                    },
+                    "experimental": {
+                        "modes": {
+                            "fast": {
+                                "cost": {
+                                    "input": 12.5,
+                                    "output": 75.0,
+                                    "cache_read": 1.25
+                                },
+                                "provider": {
+                                    "body": {
+                                        "service_tier": "priority"
+                                    }
+                                }
+                            },
+                            "preview-mode": {
+                                "cost": {
+                                    "input": 15.0,
+                                    "output": 90.0,
+                                    "cache_read": 1.5
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let models_obj = provider_data
+            .get("models")
+            .and_then(|models| models.as_object())
+            .expect("models object");
+
+        let mut collected = Vec::new();
+        for_each_active_model_with_modes(
+            models_obj,
+            |model_id, model_name, model_obj, _base_model_id, _experimental_mode, mode_obj| {
+                collected.push((
+                    model_id,
+                    model_name,
+                    model_context_limit(model_obj),
+                    is_model_free_with_mode(model_obj, mode_obj),
+                ));
+            },
+        );
+
+        assert_eq!(
+            collected,
+            vec![
+                (
+                    "gpt-5.5".to_string(),
+                    "GPT-5.5".to_string(),
+                    Some(1_050_000),
+                    false,
+                ),
+                (
+                    "gpt-5.5-fast".to_string(),
+                    "GPT-5.5 Fast".to_string(),
+                    Some(1_050_000),
+                    false,
+                ),
+                (
+                    "gpt-5.5-preview-mode".to_string(),
+                    "GPT-5.5 Preview-mode".to_string(),
+                    Some(1_050_000),
+                    false,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn experimental_modes_skip_deprecated_base_and_deprecated_fast() {
+        let provider_data = json!({
+            "models": {
+                "deprecated-base": {
+                    "name": "Deprecated Base",
+                    "status": "deprecated",
+                    "experimental": {
+                        "modes": {
+                            "fast": {}
+                        }
+                    }
+                },
+                "active-base": {
+                    "name": "Active Base",
+                    "experimental": {
+                        "modes": {
+                            "fast": {
+                                "status": "deprecated"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            collect_model_ids_and_names(&provider_data),
+            vec![("active-base".to_string(), "Active Base".to_string())]
+        );
+    }
+
+    #[test]
+    fn experimental_fast_does_not_duplicate_existing_real_model() {
+        let provider_data = json!({
+            "models": {
+                "gpt-5.5": {
+                    "name": "GPT-5.5",
+                    "experimental": {
+                        "modes": {
+                            "fast": {}
+                        }
+                    }
+                },
+                "gpt-5.5-fast": {
+                    "name": "GPT-5.5 Fast Real"
+                }
+            }
+        });
+
+        assert_eq!(
+            collect_model_ids_and_names(&provider_data),
+            vec![
+                ("gpt-5.5".to_string(), "GPT-5.5".to_string()),
+                ("gpt-5.5-fast".to_string(), "GPT-5.5 Fast Real".to_string(),),
+            ]
+        );
+    }
+
+    #[test]
+    fn experimental_fast_cost_overrides_base_cost_for_free_detection() {
+        let provider_data = json!({
+            "name": "OpenCode Zen",
+            "models": {
+                "paid-base-free-fast": {
+                    "name": "Paid Base Free Fast",
+                    "cost": {
+                        "input": 1.0,
+                        "output": 2.0
+                    },
+                    "experimental": {
+                        "modes": {
+                            "fast": {
+                                "cost": {
+                                    "input": 0.0,
+                                    "output": 0.0
+                                }
+                            }
+                        }
+                    }
+                },
+                "free-base-paid-fast": {
+                    "name": "Free Base Paid Fast",
+                    "cost": {
+                        "input": 0.0,
+                        "output": 0.0
+                    },
+                    "experimental": {
+                        "modes": {
+                            "fast": {
+                                "cost": {
+                                    "input": 1.0,
+                                    "output": 2.0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let free_model_ids: Vec<String> = filter_free_models(OPENCODE_PROVIDER_ID, &provider_data)
+            .into_iter()
+            .map(|model| model.id)
+            .collect();
+
+        assert_eq!(
+            free_model_ids,
+            vec![
+                "paid-base-free-fast-fast".to_string(),
+                "free-base-paid-fast".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn model_filters_apply_to_virtual_fast_model_ids() {
+        let models = vec![
+            UnifiedModelOption {
+                id: "openai/gpt-5.5".to_string(),
+                display_name: "OpenAI / GPT-5.5".to_string(),
+                provider_id: "openai".to_string(),
+                model_id: "gpt-5.5".to_string(),
+                is_free: false,
+                base_model_id: None,
+                experimental_mode: None,
+            },
+            UnifiedModelOption {
+                id: "openai/gpt-5.5-fast".to_string(),
+                display_name: "OpenAI / GPT-5.5 Fast".to_string(),
+                provider_id: "openai".to_string(),
+                model_id: "gpt-5.5-fast".to_string(),
+                is_free: false,
+                base_model_id: Some("gpt-5.5".to_string()),
+                experimental_mode: Some("fast".to_string()),
+            },
+        ];
+
+        let mut providers = IndexMap::new();
+        providers.insert(
+            "openai".to_string(),
+            OpenCodeProvider {
+                api: None,
+                env: None,
+                id: None,
+                npm: None,
+                name: None,
+                options: None,
+                models: IndexMap::new(),
+                whitelist: Some(vec!["gpt-5.5".to_string()]),
+                blacklist: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+
+        let filtered_ids: Vec<String> = apply_model_filters(models.clone(), Some(&providers))
+            .into_iter()
+            .map(|model| model.model_id)
+            .collect();
+        assert_eq!(filtered_ids, vec!["gpt-5.5"]);
+
+        providers.get_mut("openai").unwrap().whitelist = Some(vec!["gpt-5.5-fast".to_string()]);
+        let filtered_ids: Vec<String> = apply_model_filters(models.clone(), Some(&providers))
+            .into_iter()
+            .map(|model| model.model_id)
+            .collect();
+        assert_eq!(filtered_ids, vec!["gpt-5.5-fast"]);
+
+        providers.get_mut("openai").unwrap().whitelist = None;
+        providers.get_mut("openai").unwrap().blacklist = Some(vec!["gpt-5.5-fast".to_string()]);
+        let filtered_ids: Vec<String> = apply_model_filters(models, Some(&providers))
+            .into_iter()
+            .map(|model| model.model_id)
+            .collect();
+        assert_eq!(filtered_ids, vec!["gpt-5.5"]);
     }
 }

--- a/tauri/src/coding/open_code/tray_support.rs
+++ b/tauri/src/coding/open_code/tray_support.rs
@@ -176,6 +176,18 @@ fn find_model_display_name(items: &[TrayModelItem], current: &str) -> String {
     current.to_string()
 }
 
+fn parse_model_item_id(item_id: &str) -> Result<(&str, &str), String> {
+    let (provider_id, model_id) = item_id
+        .split_once('/')
+        .ok_or_else(|| format!("Invalid model ID format: {}", item_id))?;
+
+    if provider_id.is_empty() || model_id.is_empty() {
+        return Err(format!("Invalid model ID format: {}", item_id));
+    }
+
+    Ok((provider_id, model_id))
+}
+
 /// Apply model selection from tray menu
 pub async fn apply_opencode_model<R: Runtime>(
     app: &AppHandle<R>,
@@ -183,13 +195,7 @@ pub async fn apply_opencode_model<R: Runtime>(
     item_id: &str,    // Format: "provider/model"
 ) -> Result<(), String> {
     // Parse item_id to get provider_id and model_id
-    let parts: Vec<&str> = item_id.split('/').collect();
-    if parts.len() != 2 {
-        return Err(format!("Invalid model ID format: {}", item_id));
-    }
-
-    let provider_id = parts[0];
-    let model_id = parts[1];
+    let (provider_id, model_id) = parse_model_item_id(item_id)?;
 
     // Read current config
     let result = read_opencode_config(app.state()).await?;
@@ -473,7 +479,10 @@ pub async fn apply_opencode_plugin<R: Runtime>(
 
 #[cfg(test)]
 mod tests {
-    use super::{remember_plugin_entry, remembered_plugin_entries, remembered_plugin_entry};
+    use super::{
+        parse_model_item_id, remember_plugin_entry, remembered_plugin_entries,
+        remembered_plugin_entry,
+    };
     use crate::coding::open_code::types::OpenCodePluginEntry;
     use serde_json::json;
 
@@ -497,5 +506,20 @@ mod tests {
             remembered_plugin_entry("oh-my-opencode"),
             Some(tuple_plugin_entry)
         );
+    }
+
+    #[test]
+    fn parse_model_item_id_keeps_slashes_inside_model_id() {
+        assert_eq!(
+            parse_model_item_id("zenmux/openai/gpt-5.5-fast"),
+            Ok(("zenmux", "openai/gpt-5.5-fast"))
+        );
+    }
+
+    #[test]
+    fn parse_model_item_id_rejects_missing_provider_or_model() {
+        assert!(parse_model_item_id("gpt-5.5-fast").is_err());
+        assert!(parse_model_item_id("/gpt-5.5-fast").is_err());
+        assert!(parse_model_item_id("opencode/").is_err());
     }
 }

--- a/tauri/src/coding/open_code/types.rs
+++ b/tauri/src/coding/open_code/types.rs
@@ -293,6 +293,10 @@ pub struct FreeModel {
     pub provider_name: String, // Display name (e.g., "OpenCode Zen")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental_mode: Option<String>,
 }
 
 /// Provider models data stored in database
@@ -337,6 +341,10 @@ pub struct UnifiedModelOption {
     pub provider_id: String,
     pub model_id: String,
     pub is_free: bool, // Whether this is a free model
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental_mode: Option<String>,
 }
 
 // ============================================================================

--- a/web/features/coding/opencode/AGENTS.md
+++ b/web/features/coding/opencode/AGENTS.md
@@ -9,6 +9,7 @@
 - 页面展示的配置内容来自当前生效配置文件；`configPathInfo` 只说明路径来源，不说明是否 WSL Direct。
 - `configPathInfo` 由后端 `getOpenCodeConfigPathInfo()` 返回；当前生效 prompt 路径由后端按配置文件所在目录推导。
 - 页面里的主模型和小模型值都应视为完整 `provider_id/model_id`，而不是单独的模型名。
+- 后端统一模型列表会把 models.dev 的 `experimental.modes.*` 展开为虚拟模型，并通过 `baseModelId` / `experimentalMode` 标记来源；页面里的 variant dropdown 应基于这些元数据继承 base model variants，不要靠 `-fast` 等后缀猜测。
 - `favorite provider` 列表和诊断属于辅助历史状态，不能反推为 OpenCode 当前运行时真实配置。
 
 ## 核心设计决策（Why）
@@ -41,6 +42,7 @@ sequenceDiagram
 - 不要把 OpenCode 页面上的 `configPathInfo.source === custom` 误解成“当前是 WSL Direct”；这两个概念无关。
 - 改 prompt 行为时要记住运行时文件名就是当前配置目录下的 `AGENTS.md`，不是独立根目录。
 - 不要把模型选项只按 `model_id` 处理。页面、后端和 tray 共享的契约是完整 `provider_id/model_id`，否则选中态、保存值和 tray 菜单会分叉。
+- 不要从模型 ID 后缀推断 experimental mode；真实模型名也可能包含 `fast` 等片段。只信任后端返回的 `baseModelId` / `experimentalMode` 元数据。
 - `favorite provider` 页内列表的语义是“使用过的供应商”和诊断缓存，不是“当前配置中的 provider 列表”；删除当前 provider 前后保留它是可能的预期行为。
 - 改模型刷新或 provider 导入时，不要忘了托盘刷新和 favorite provider 辅助状态更新。
 - “其他配置”是 OpenCode 顶层配置的补充 JSON 编辑面。`disabled_providers` 虽然也被 provider 卡片开关消费，但没有独立表单字段，不能从“其他配置”中过滤掉；保存时也要允许用户通过删除该字段来清空禁用列表。

--- a/web/services/opencodeApi.ts
+++ b/web/services/opencodeApi.ts
@@ -113,6 +113,8 @@ export interface FreeModel {
   providerId: string;       // Config key (e.g., "opencode")
   providerName: string;     // Display name (e.g., "OpenCode Zen")
   context?: number;
+  baseModelId?: string;
+  experimentalMode?: string;
 }
 
 /**
@@ -158,6 +160,8 @@ export interface UnifiedModelOption {
   providerId: string;
   modelId: string;
   isFree: boolean;      // Whether this is a free model
+  baseModelId?: string;
+  experimentalMode?: string;
 }
 
 /**
@@ -185,6 +189,8 @@ export const buildModelVariantsMap = (
   presetModels?: Record<string, Array<{ id: string; variants?: Record<string, unknown> }>>
 ): Record<string, string[]> => {
   const variantsMap: Record<string, string[]> = {};
+  const variantKeysByConfiguredModel = new Map<string, string[]>();
+  const variantKeysByPresetModel = new Map<string, string[]>();
 
   // Get variants from config providers
   if (config?.provider) {
@@ -192,7 +198,10 @@ export const buildModelVariantsMap = (
       if (provider.models) {
         Object.entries(provider.models).forEach(([modelId, model]) => {
           if (model.variants && Object.keys(model.variants).length > 0) {
-            variantsMap[`${providerId}/${modelId}`] = Object.keys(model.variants);
+            const variantKeys = Object.keys(model.variants);
+            const fullModelId = `${providerId}/${modelId}`;
+            variantKeysByConfiguredModel.set(fullModelId, variantKeys);
+            variantsMap[fullModelId] = variantKeys;
           }
         });
       }
@@ -205,6 +214,7 @@ export const buildModelVariantsMap = (
       models.forEach((model) => {
         if (model.variants && Object.keys(model.variants).length > 0) {
           const variantKeys = Object.keys(model.variants);
+          variantKeysByPresetModel.set(model.id, variantKeys);
           // Match preset model ID with unified model IDs
           unifiedModels.forEach((um) => {
             if (um.modelId === model.id && !variantsMap[um.id]) {
@@ -215,6 +225,22 @@ export const buildModelVariantsMap = (
       });
     });
   }
+
+  // OpenCode expands models.dev experimental modes into virtual model IDs,
+  // e.g. gpt-5.5 + mode fast -> gpt-5.5-fast. Those virtual models inherit
+  // the base model variants, so the variant dropdown should remain available.
+  unifiedModels.forEach((um) => {
+    if (variantsMap[um.id]) return;
+    if (!um.baseModelId || !um.experimentalMode) return;
+
+    const baseUnifiedId = `${um.providerId}/${um.baseModelId}`;
+    const baseVariantKeys = variantsMap[baseUnifiedId]
+      ?? variantKeysByConfiguredModel.get(baseUnifiedId)
+      ?? variantKeysByPresetModel.get(um.baseModelId);
+    if (baseVariantKeys && baseVariantKeys.length > 0) {
+      variantsMap[um.id] = baseVariantKeys;
+    }
+  });
 
   return variantsMap;
 };

--- a/web/test/features/coding/opencode/services/opencodeApi.test.ts
+++ b/web/test/features/coding/opencode/services/opencodeApi.test.ts
@@ -1,0 +1,150 @@
+/// <reference types="node" />
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildModelVariantsMap,
+  type UnifiedModelOption,
+} from '../../../../../services/opencodeApi.ts';
+
+test('buildModelVariantsMap maps experimental virtual models to base variants', () => {
+  const unifiedModels: UnifiedModelOption[] = [
+    {
+      id: 'opencode/gpt-5.5',
+      displayName: 'OpenCode Zen / GPT-5.5',
+      providerId: 'opencode',
+      modelId: 'gpt-5.5',
+      isFree: false,
+    },
+    {
+      id: 'opencode/gpt-5.5-fast',
+      displayName: 'OpenCode Zen / GPT-5.5 Fast',
+      providerId: 'opencode',
+      modelId: 'gpt-5.5-fast',
+      isFree: false,
+      baseModelId: 'gpt-5.5',
+      experimentalMode: 'fast',
+    },
+    {
+      id: 'opencode/gpt-5.5-preview-mode',
+      displayName: 'OpenCode Zen / GPT-5.5 Preview-mode',
+      providerId: 'opencode',
+      modelId: 'gpt-5.5-preview-mode',
+      isFree: false,
+      baseModelId: 'gpt-5.5',
+      experimentalMode: 'preview-mode',
+    },
+    {
+      id: 'opencode/gpt-5.5-pro',
+      displayName: 'OpenCode Zen / GPT-5.5 Pro',
+      providerId: 'opencode',
+      modelId: 'gpt-5.5-pro',
+      isFree: false,
+    },
+  ];
+
+  const variantsMap = buildModelVariantsMap(null, unifiedModels, {
+    '@ai-sdk/openai': [
+      {
+        id: 'gpt-5.5',
+        variants: {
+          medium: {},
+          high: {},
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(variantsMap['opencode/gpt-5.5'], ['medium', 'high']);
+  assert.deepEqual(variantsMap['opencode/gpt-5.5-fast'], ['medium', 'high']);
+  assert.deepEqual(variantsMap['opencode/gpt-5.5-preview-mode'], ['medium', 'high']);
+  assert.equal(variantsMap['opencode/gpt-5.5-pro'], undefined);
+});
+
+test('buildModelVariantsMap lets experimental models inherit custom config variants', () => {
+  const unifiedModels: UnifiedModelOption[] = [
+    {
+      id: 'openai/openai/gpt-5.5-fast',
+      displayName: 'OpenAI Compatible / GPT-5.5 Fast',
+      providerId: 'openai',
+      modelId: 'openai/gpt-5.5-fast',
+      isFree: false,
+      baseModelId: 'openai/gpt-5.5',
+      experimentalMode: 'fast',
+    },
+  ];
+
+  const variantsMap = buildModelVariantsMap(
+    {
+      provider: {
+        openai: {
+          models: {
+            'openai/gpt-5.5': {
+              variants: {
+                customHigh: {},
+              },
+            },
+          },
+        },
+      },
+    },
+    unifiedModels,
+    undefined,
+  );
+
+  assert.deepEqual(variantsMap['openai/openai/gpt-5.5-fast'], ['customHigh']);
+});
+
+test('buildModelVariantsMap keeps experimental variants when base model is filtered out', () => {
+  const unifiedModels: UnifiedModelOption[] = [
+    {
+      id: 'opencode/gpt-5.5-fast',
+      displayName: 'OpenCode Zen / GPT-5.5 Fast',
+      providerId: 'opencode',
+      modelId: 'gpt-5.5-fast',
+      isFree: false,
+      baseModelId: 'gpt-5.5',
+      experimentalMode: 'fast',
+    },
+  ];
+
+  const variantsMap = buildModelVariantsMap(null, unifiedModels, {
+    '@ai-sdk/openai': [
+      {
+        id: 'gpt-5.5',
+        variants: {
+          medium: {},
+          high: {},
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(variantsMap['opencode/gpt-5.5-fast'], ['medium', 'high']);
+});
+
+test('buildModelVariantsMap does not infer experimental models from suffix alone', () => {
+  const unifiedModels: UnifiedModelOption[] = [
+    {
+      id: 'opencode/grok-code-fast-1',
+      displayName: 'OpenCode Zen / grok-code-fast-1',
+      providerId: 'opencode',
+      modelId: 'grok-code-fast-1',
+      isFree: false,
+    },
+  ];
+
+  const variantsMap = buildModelVariantsMap(null, unifiedModels, {
+    '@ai-sdk/openai': [
+      {
+        id: 'grok-code-fast',
+        variants: {
+          high: {},
+        },
+      },
+    ],
+  });
+
+  assert.equal(variantsMap['opencode/grok-code-fast-1'], undefined);
+});


### PR DESCRIPTION
## 背景

Issue #177 反馈：OpenCode 已经支持并展示 `GPT-5.5 Fast`、`GPT-5.4 Fast`、`GPT-5.4 mini Fast` 等 Fast 模型，但 AI Toolbox 的 OpenCode 模型下拉里缺少这些选项。

这些 Fast 模型不是 `models.dev` 里的独立静态模型条目。OpenCode 的做法是读取 `models.dev` 中基础模型的 `experimental.modes.*` 元数据，并展开成虚拟模型 ID，例如：`gpt-5.5` 的 `experimental.modes.fast` 会派生出 `gpt-5.5-fast`。

## 修复方案

- 在 OpenCode 统一模型列表中通用展开 `models.dev` 的 `experimental.modes.*`。
- 为虚拟模型保留 `baseModelId` / `experimentalMode` 元数据，让前端基于元数据继承基础模型 variants，而不是依赖 `-fast` 后缀猜测。
- 保存值继续保持 OpenCode 现有的 `provider_id/model_id` 格式。
- 修复托盘模型解析逻辑，只按第一个 `/` 分隔 provider 和 model，避免 model ID 自身包含 `/` 时解析错误。
- 增加回归测试覆盖：
  - 通用 experimental mode 展开；
  - deprecated base/mode 过滤；
  - 真实模型与虚拟模型 ID 冲突时真实模型优先；
  - mode cost 覆盖 base cost 后的免费模型判定；
  - whitelist/blacklist 对虚拟模型 ID 的行为；
  - 基础模型被过滤时虚拟模型仍能继承 variants；
  - 托盘支持 model ID 包含 `/`。
- 在 OpenCode 前后端模块 AGENTS 文档中补充 experimental mode 和 model ID 解析规则。

## 验证

- `cargo test open_code::free_models::tests`
- `cargo test open_code::tray_support::tests`
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `git diff --check`

Closes #177