### PR TITLE
feat(ssh): 优化目录同步可见性

### DIFF
--- a/tauri/src/coding/ssh/AGENTS.md
+++ b/tauri/src/coding/ssh/AGENTS.md
@@ -44,6 +44,7 @@ sequenceDiagram
   映射和动态路径是否正确；
   MCP/Skills 独立同步链路是否执行。
 - Claude Code 本机自定义根目录只改变本机源路径，不改变普通 SSH 远端目标布局；`CLAUDE_CODE_PLUGIN_CACHE_DIR` 也只改变本机 plugin 源目录。远端仍应同步到默认 `~/.claude/*`、`~/.claude/plugins`、`~/.claude/skills` 和 `~/.claude.json`；只有本机路径本身是 WSL Direct 自定义根目录时，SSH 的本地源会是 UNC，远端目标仍按后端动态解析结果处理。
+- SSH 普通 file mapping 的目录模式支持按目录名配置 `directory_excludes`，默认跳过 `.git`、`.venv`、`venv`、`node_modules`、`__pycache__`、`.pytest_cache`、`.mypy_cache`、`cache`。匹配语义是目录名 segment 精确匹配，不是 glob/gitignore；非目录和 glob mapping 不应受影响。Skills 独立 SSH 目录上传也要复用同一默认排除，避免中央 Skill 内的 `.venv` 被整目录上传。
 - 对 Claude `claude-plugins` 目录，同步到远端后还要修补 `known_marketplaces.json` / `installed_plugins.json` 里的 `installLocation` / `installPath`。这些字段若保留 Windows 本机路径，远端插件运行时不会自动替你转换。
 - Claude 插件元数据补写属于 best-effort 后处理。即使 `known_marketplaces.json` / `installed_plugins.json` 读取、改写或写回失败，也不能把已经成功完成的主文件同步整体标成失败；最多记录 warning/error 供排查。
 - 写入到 `known_marketplaces.json` / `installed_plugins.json` 的 `installLocation` / `installPath` **必须是远端真实绝对 Linux 路径**，不能保留 `~/.claude/...`。Claude CLI 2.1.126+ 不会展开 JSON 字段值里的 `~`，留 `~` 会被判定 corrupted。读写文件路径可继续走 `read_remote_file` / `write_remote_file` 的 `$HOME` 展开；但作为字段**值**落盘前，必须先用 `sync::get_remote_user_home(session)` 拿到远端真实 `$HOME`，再交给重写逻辑。这条规则也覆盖以后任何往工具配置里写"远端路径字段值"的同步场景。

--- a/tauri/src/coding/ssh/adapter.rs
+++ b/tauri/src/coding/ssh/adapter.rs
@@ -1,5 +1,8 @@
 use super::super::db_id;
-use super::types::{SSHConnection, SSHFileMapping, SSHSyncConfig};
+use super::types::{
+    default_directory_excludes, normalize_directory_excludes, SSHConnection, SSHFileMapping,
+    SSHSyncConfig,
+};
 use chrono::Local;
 use serde_json::{json, Value};
 
@@ -143,9 +146,40 @@ pub fn connection_to_db_value(conn: &SSHConnection) -> Value {
 // SSH File Mapping Adapter Functions
 // ============================================================================
 
+fn directory_excludes_from_db_value(value: &Value, is_directory: bool) -> Vec<String> {
+    if !is_directory {
+        return vec![];
+    }
+
+    let Some(raw_excludes) = value
+        .get("directory_excludes")
+        .or_else(|| value.get("directoryExcludes"))
+    else {
+        return default_directory_excludes();
+    };
+
+    let excludes = raw_excludes
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    normalize_directory_excludes(&excludes)
+}
+
 /// Convert database Value to SSHFileMapping
 pub fn mapping_from_db_value(value: Value) -> SSHFileMapping {
     let id = db_id::db_extract_id(&value);
+    let is_directory = value
+        .get("is_directory")
+        .or_else(|| value.get("isDirectory"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let directory_excludes = directory_excludes_from_db_value(&value, is_directory);
 
     SSHFileMapping {
         id,
@@ -180,16 +214,19 @@ pub fn mapping_from_db_value(value: Value) -> SSHFileMapping {
             .or_else(|| value.get("isPattern"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
-        is_directory: value
-            .get("is_directory")
-            .or_else(|| value.get("isDirectory"))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
+        is_directory,
+        directory_excludes,
     }
 }
 
 /// Convert SSHFileMapping to database Value
 pub fn mapping_to_db_value(mapping: &SSHFileMapping) -> Value {
+    let directory_excludes = if mapping.is_directory {
+        normalize_directory_excludes(&mapping.directory_excludes)
+    } else {
+        vec![]
+    };
+
     json!({
         "name": mapping.name,
         "module": mapping.module,
@@ -198,6 +235,68 @@ pub fn mapping_to_db_value(mapping: &SSHFileMapping) -> Value {
         "enabled": mapping.enabled,
         "is_pattern": mapping.is_pattern,
         "is_directory": mapping.is_directory,
+        "directory_excludes": directory_excludes,
         "updated_at": Local::now().to_rfc3339(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mapping_from_db_value, mapping_to_db_value};
+    use serde_json::json;
+
+    #[test]
+    fn directory_mapping_without_saved_excludes_uses_defaults() {
+        let mapping = mapping_from_db_value(json!({
+            "id": "ssh_file_mapping:claude-plugins",
+            "name": "Claude Code 插件目录",
+            "module": "claude",
+            "local_path": "~/.claude/plugins",
+            "remote_path": "~/.claude/plugins",
+            "enabled": true,
+            "is_pattern": false,
+            "is_directory": true,
+        }));
+
+        assert!(mapping.directory_excludes.contains(&"cache".to_string()));
+        assert!(mapping.directory_excludes.contains(&".venv".to_string()));
+    }
+
+    #[test]
+    fn explicit_empty_directory_excludes_are_preserved() {
+        let mapping = mapping_from_db_value(json!({
+            "id": "ssh_file_mapping:custom-dir",
+            "name": "Custom Dir",
+            "module": "claude",
+            "local_path": "~/src",
+            "remote_path": "~/src",
+            "enabled": true,
+            "is_pattern": false,
+            "is_directory": true,
+            "directory_excludes": [],
+        }));
+
+        assert!(mapping.directory_excludes.is_empty());
+    }
+
+    #[test]
+    fn non_directory_mapping_does_not_persist_excludes() {
+        let mapping = mapping_from_db_value(json!({
+            "id": "ssh_file_mapping:opencode-plugins",
+            "name": "OpenCode 插件文件",
+            "module": "opencode",
+            "local_path": "~/.config/opencode/*.mjs",
+            "remote_path": "~/.config/opencode/",
+            "enabled": true,
+            "is_pattern": true,
+            "is_directory": false,
+            "directory_excludes": ["cache"],
+        }));
+
+        assert!(mapping.directory_excludes.is_empty());
+        assert_eq!(
+            mapping_to_db_value(&mapping)["directory_excludes"],
+            json!([])
+        );
+    }
 }

--- a/tauri/src/coding/ssh/commands.rs
+++ b/tauri/src/coding/ssh/commands.rs
@@ -484,6 +484,7 @@ pub async fn do_full_sync(
             current: 0,
             total: total_files,
             message: format!("文件同步: 0/{}", total_files),
+            current_file: None,
         },
     );
 
@@ -712,12 +713,35 @@ async fn sync_mappings_with_progress(
                 current,
                 total,
                 message: format!("文件同步: {}/{} - {}", current, total, mapping.name),
+                current_file: None,
             },
         );
 
-        match sync::sync_file_mapping(mapping, session).await {
+        let report_current_file = |current_file: String| {
+            let _ = app.emit(
+                "ssh-sync-progress",
+                SyncProgress {
+                    phase: "files".to_string(),
+                    current_item: mapping.name.clone(),
+                    current,
+                    total,
+                    message: format!("文件同步: {}/{} - {}", current, total, mapping.name),
+                    current_file: Some(current_file),
+                },
+            );
+        };
+
+        match sync::sync_file_mapping_with_progress(mapping, session, Some(&report_current_file))
+            .await
+        {
             Ok(mut files) => {
-                match reconcile_codex_prompt_files_on_ssh(mapping, session).await {
+                match reconcile_codex_prompt_files_on_ssh(
+                    mapping,
+                    session,
+                    Some(&report_current_file),
+                )
+                .await
+                {
                     Ok(prompt_files) => files.extend(prompt_files),
                     Err(error) => errors.push(format!("{}: {}", mapping.name, error)),
                 }
@@ -769,6 +793,7 @@ async fn sync_mappings_with_progress(
 async fn reconcile_codex_prompt_files_on_ssh(
     mapping: &SSHFileMapping,
     session: &SshSession,
+    current_file_reporter: Option<&(dyn Fn(String) + Send + Sync)>,
 ) -> Result<Vec<String>, String> {
     if mapping.id != "codex-prompt" || mapping.is_directory || mapping.is_pattern {
         return Ok(vec![]);
@@ -784,8 +809,15 @@ async fn reconcile_codex_prompt_files_on_ssh(
             if local_path == mapping.local_path && remote_path == mapping.remote_path {
                 continue;
             }
-            synced_files
-                .extend(sync::sync_single_file(&expanded_local_path, &remote_path, session).await?);
+            synced_files.extend(
+                sync::sync_single_file_with_progress(
+                    &expanded_local_path,
+                    &remote_path,
+                    session,
+                    current_file_reporter,
+                )
+                .await?,
+            );
         } else {
             sync::remove_remote_path(session, &remote_path).await?;
             synced_files.push(format!("removed stale Codex prompt: {}", remote_path));
@@ -1238,6 +1270,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "opencode-oh-my".to_string(),
@@ -1248,6 +1281,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "opencode-oh-my-slim".to_string(),
@@ -1258,6 +1292,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: false,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "opencode-auth".to_string(),
@@ -1268,6 +1303,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "opencode-plugins".to_string(),
@@ -1278,6 +1314,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: true,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "opencode-prompt".to_string(),
@@ -1288,6 +1325,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         // Claude Code
         SSHFileMapping {
@@ -1299,6 +1337,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "claude-config".to_string(),
@@ -1309,6 +1348,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "claude-prompt".to_string(),
@@ -1319,6 +1359,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "claude-plugins".to_string(),
@@ -1329,6 +1370,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: true,
+            directory_excludes: super::types::default_directory_excludes(),
         },
         // Codex
         SSHFileMapping {
@@ -1340,6 +1382,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "codex-config".to_string(),
@@ -1350,6 +1393,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "codex-prompt".to_string(),
@@ -1360,6 +1404,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "codex-plugins".to_string(),
@@ -1370,6 +1415,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: true,
+            directory_excludes: super::types::default_directory_excludes(),
         },
         // OpenClaw
         SSHFileMapping {
@@ -1381,6 +1427,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         // Gemini CLI
         SSHFileMapping {
@@ -1392,6 +1439,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "geminicli-settings".to_string(),
@@ -1402,6 +1450,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "geminicli-prompt".to_string(),
@@ -1412,6 +1461,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
         SSHFileMapping {
             id: "geminicli-oauth".to_string(),
@@ -1422,6 +1472,7 @@ pub fn default_file_mappings() -> Vec<SSHFileMapping> {
             enabled: true,
             is_pattern: false,
             is_directory: false,
+            directory_excludes: vec![],
         },
     ]
 }

--- a/tauri/src/coding/ssh/mcp_sync.rs
+++ b/tauri/src/coding/ssh/mcp_sync.rs
@@ -68,6 +68,7 @@ pub async fn sync_mcp_to_ssh(
             current: 1,
             total: 2,
             message: "MCP 同步: Claude Code...".to_string(),
+            current_file: None,
         },
     );
 
@@ -104,6 +105,7 @@ pub async fn sync_mcp_to_ssh(
             current: 2,
             total: 2,
             message: "MCP 同步: OpenCode/Codex/Gemini CLI...".to_string(),
+            current_file: None,
         },
     );
 

--- a/tauri/src/coding/ssh/session.rs
+++ b/tauri/src/coding/ssh/session.rs
@@ -3,6 +3,7 @@
 //! 维护一个进程内持久 SSH 连接，所有操作复用该连接。
 //! 网络断开后自动重连。跨平台兼容（Windows/macOS/Linux）。
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -385,13 +386,57 @@ impl SshSession {
 
     /// 通过 SFTP 递归上传目录
     pub async fn upload_dir(&self, local_path: &str, remote_path: &str) -> Result<(), String> {
+        self.upload_dir_with_excludes(local_path, remote_path, &[])
+            .await
+    }
+
+    /// 通过 SFTP 递归上传目录，并按目录名跳过 excluded folders
+    pub async fn upload_dir_with_excludes(
+        &self,
+        local_path: &str,
+        remote_path: &str,
+        excluded_names: &[String],
+    ) -> Result<(), String> {
+        self.upload_dir_with_excludes_and_progress(local_path, remote_path, excluded_names, None)
+            .await
+    }
+
+    /// 通过 SFTP 递归上传目录，并在每个实际上传文件前报告相对路径
+    pub async fn upload_dir_with_excludes_and_progress(
+        &self,
+        local_path: &str,
+        remote_path: &str,
+        excluded_names: &[String],
+        current_file_reporter: Option<&(dyn Fn(String) + Send + Sync)>,
+    ) -> Result<(), String> {
         let sftp = self.create_sftp_session().await?;
 
         // 将 ~ 展开为绝对路径
         let abs_remote_path = resolve_remote_path(&sftp, remote_path).await?;
+        let excluded_names: HashSet<String> = excluded_names.iter().cloned().collect();
+        let mut stats = DirectoryUploadStats::default();
+        let local_root = std::path::Path::new(local_path);
 
         // 递归上传
-        upload_dir_recursive(&sftp, std::path::Path::new(local_path), &abs_remote_path).await
+        upload_dir_recursive(
+            &sftp,
+            local_root,
+            local_root,
+            &abs_remote_path,
+            &excluded_names,
+            &mut stats,
+            current_file_reporter,
+        )
+        .await?;
+
+        if stats.skipped_excluded_dirs > 0 {
+            info!(
+                "SSH directory upload skipped excluded directories: local_path={}, remote_path={}, skipped_count={}, excludes={:?}",
+                local_path, remote_path, stats.skipped_excluded_dirs, excluded_names
+            );
+        }
+
+        Ok(())
     }
 
     /// 获取 user@host 字符串
@@ -518,12 +563,35 @@ pub async fn upload_file_via_sftp(
     Ok(())
 }
 
+#[derive(Default)]
+struct DirectoryUploadStats {
+    skipped_excluded_dirs: usize,
+}
+
+const MAX_EXCLUDED_DIR_TRACE_LOGS: usize = 20;
+
+fn is_excluded_dir_name(file_name: &str, excluded_names: &HashSet<String>) -> bool {
+    excluded_names.contains(file_name)
+}
+
+fn relative_upload_path(base_dir: &std::path::Path, file_path: &std::path::Path) -> String {
+    file_path
+        .strip_prefix(base_dir)
+        .unwrap_or(file_path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 /// 递归上传目录内容到远程
 /// 使用 tokio::fs::metadata 跟随符号链接，等同于 cp -rL 行为
 async fn upload_dir_recursive(
     sftp: &russh_sftp::client::SftpSession,
+    base_dir: &std::path::Path,
     local_dir: &std::path::Path,
     remote_dir: &str,
+    excluded_names: &HashSet<String>,
+    stats: &mut DirectoryUploadStats,
+    current_file_reporter: Option<&(dyn Fn(String) + Send + Sync)>,
 ) -> Result<(), String> {
     // 创建远程目录（忽略已存在的错误）
     let _ = sftp.create_dir(remote_dir).await;
@@ -546,8 +614,34 @@ async fn upload_dir_recursive(
         let remote_child = format!("{}/{}", remote_dir, file_name);
 
         if metadata.is_dir() {
-            Box::pin(upload_dir_recursive(sftp, &path, &remote_child)).await?;
+            if is_excluded_dir_name(&file_name, excluded_names) {
+                stats.skipped_excluded_dirs += 1;
+                if stats.skipped_excluded_dirs <= MAX_EXCLUDED_DIR_TRACE_LOGS {
+                    log::trace!(
+                        "SSH directory upload skipped excluded directory: local_path={}, remote_path={}, exclude_name={}",
+                        path.display(),
+                        remote_child,
+                        file_name
+                    );
+                }
+                continue;
+            }
+
+            Box::pin(upload_dir_recursive(
+                sftp,
+                base_dir,
+                &path,
+                &remote_child,
+                excluded_names,
+                stats,
+                current_file_reporter,
+            ))
+            .await?;
         } else if metadata.is_file() {
+            if let Some(reporter) = current_file_reporter {
+                reporter(relative_upload_path(base_dir, &path));
+            }
+
             let data = tokio::fs::read(&path)
                 .await
                 .map_err(|e| format!("读取文件失败 {}: {}", path.display(), e))?;
@@ -628,5 +722,30 @@ impl Drop for SshSession {
     fn drop(&mut self) {
         // 在 Drop 中不能 async，直接丢弃 handle 让 russh 自行清理
         self.handle.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_excluded_dir_name, relative_upload_path};
+    use std::collections::HashSet;
+    use std::path::Path;
+
+    #[test]
+    fn matches_excluded_directory_by_name_segment_only() {
+        let excluded = HashSet::from(["cache".to_string(), ".venv".to_string()]);
+
+        assert!(is_excluded_dir_name("cache", &excluded));
+        assert!(is_excluded_dir_name(".venv", &excluded));
+        assert!(!is_excluded_dir_name("plugin-cache", &excluded));
+        assert!(!is_excluded_dir_name("cache/nested", &excluded));
+    }
+
+    #[test]
+    fn reports_directory_upload_paths_relative_to_mapping_root() {
+        let base = Path::new("/tmp/plugins");
+        let file = Path::new("/tmp/plugins/marketplace/cache.json");
+
+        assert_eq!(relative_upload_path(base, file), "marketplace/cache.json");
     }
 }

--- a/tauri/src/coding/ssh/skills_sync.rs
+++ b/tauri/src/coding/ssh/skills_sync.rs
@@ -11,9 +11,9 @@ use super::commands::get_ssh_config_internal;
 use super::session::SshSession;
 use super::sync::{
     check_remote_symlink_exists, create_remote_symlink, list_remote_dir, read_remote_file_raw,
-    remove_remote_path, sync_directory, write_remote_file,
+    remove_remote_path, sync_directory_with_progress, write_remote_file,
 };
-use super::types::SyncProgress;
+use super::types::{default_directory_excludes, SyncProgress};
 use crate::coding::runtime_location;
 use crate::coding::skills::central_repo::{resolve_central_repo_path, resolve_skill_central_path};
 use crate::coding::skills::skill_store;
@@ -104,6 +104,7 @@ pub async fn sync_skills_to_ssh(
             current: 0,
             total: total_skills,
             message: format!("Skills 同步: 0/{}", total_skills),
+            current_file: None,
         },
     );
 
@@ -171,6 +172,7 @@ pub async fn sync_skills_to_ssh(
                     "Skills 同步: {}/{} - {}",
                     current_idx, total_skills, skill.name
                 ),
+                current_file: None,
             },
         );
 
@@ -215,7 +217,32 @@ pub async fn sync_skills_to_ssh(
                 source_str,
                 remote_target
             );
-            match sync_directory(&source_str, &remote_target, session).await {
+            let report_current_file = |current_file: String| {
+                let _ = app.emit(
+                    "ssh-sync-progress",
+                    SyncProgress {
+                        phase: "skills".to_string(),
+                        current_item: skill.name.clone(),
+                        current: current_idx,
+                        total: total_skills,
+                        message: format!(
+                            "Skills 同步: {}/{} - {}",
+                            current_idx, total_skills, skill.name
+                        ),
+                        current_file: Some(current_file),
+                    },
+                );
+            };
+
+            match sync_directory_with_progress(
+                &source_str,
+                &remote_target,
+                session,
+                &default_directory_excludes(),
+                Some(&report_current_file),
+            )
+            .await
+            {
                 Ok(_) => {
                     if let Err(e) = write_remote_file(session, &hash_file, local_hash).await {
                         log::warn!(

--- a/tauri/src/coding/ssh/sync.rs
+++ b/tauri/src/coding/ssh/sync.rs
@@ -1,6 +1,10 @@
 use super::session::{self, upload_file_via_sftp, SshSession};
-use super::types::{SSHConnection, SSHConnectionResult, SSHFileMapping, SyncResult};
-use std::path::Path;
+use super::types::{
+    normalize_directory_excludes, SSHConnection, SSHConnectionResult, SSHFileMapping, SyncResult,
+};
+use std::path::{Path, PathBuf};
+
+type CurrentFileReporter<'a> = &'a (dyn Fn(String) + Send + Sync);
 
 fn mapping_kind(mapping: &SSHFileMapping) -> &'static str {
     if mapping.is_directory {
@@ -10,6 +14,49 @@ fn mapping_kind(mapping: &SSHFileMapping) -> &'static str {
     } else {
         "file"
     }
+}
+
+fn normalize_display_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn file_name_or_path(path: &Path, fallback: &str) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(normalize_display_path)
+        .unwrap_or_else(|| normalize_display_path(fallback))
+}
+
+fn glob_static_base(pattern: &str) -> Option<PathBuf> {
+    let meta_index = pattern
+        .char_indices()
+        .find(|(_, ch)| matches!(ch, '*' | '?' | '['))
+        .map(|(index, _)| index)?;
+    let prefix = &pattern[..meta_index];
+    if prefix.is_empty() {
+        return None;
+    }
+
+    let prefix_path = Path::new(prefix);
+    if prefix.ends_with('/') || prefix.ends_with('\\') {
+        Some(prefix_path.to_path_buf())
+    } else {
+        prefix_path.parent().map(Path::to_path_buf)
+    }
+}
+
+fn pattern_file_display_path(expanded_pattern: &str, file_path: &Path) -> String {
+    if let Some(base_dir) = glob_static_base(expanded_pattern) {
+        if let Ok(relative_path) = file_path.strip_prefix(&base_dir) {
+            let display = normalize_display_path(&relative_path.to_string_lossy());
+            if !display.is_empty() {
+                return display;
+            }
+        }
+    }
+
+    file_name_or_path(file_path, &file_path.to_string_lossy())
 }
 
 // ============================================================================
@@ -54,10 +101,11 @@ pub fn expand_local_path(path: &str) -> Result<String, String> {
 // ============================================================================
 
 /// 同步单个文件到远程（通过 SFTP）
-pub async fn sync_single_file(
+pub async fn sync_single_file_with_progress(
     local_path: &str,
     remote_path: &str,
     session: &SshSession,
+    current_file_reporter: Option<CurrentFileReporter<'_>>,
 ) -> Result<Vec<String>, String> {
     let expanded = expand_local_path(local_path)?;
     log::trace!(
@@ -75,6 +123,10 @@ pub async fn sync_single_file(
             remote_path
         );
         return Ok(vec![]);
+    }
+
+    if let Some(reporter) = current_file_reporter {
+        reporter(file_name_or_path(Path::new(&expanded), local_path));
     }
 
     let remote_target = remote_path.replace("~", "$HOME");
@@ -96,17 +148,21 @@ pub async fn sync_single_file(
 
 /// 同步整个目录到远程（通过 SFTP）
 /// 使用临时目录 + mv 实现原子替换，防止上传中断导致数据丢失
-pub async fn sync_directory(
+pub async fn sync_directory_with_progress(
     local_path: &str,
     remote_path: &str,
     session: &SshSession,
+    directory_excludes: &[String],
+    current_file_reporter: Option<CurrentFileReporter<'_>>,
 ) -> Result<Vec<String>, String> {
     let expanded = expand_local_path(local_path)?;
+    let directory_excludes = normalize_directory_excludes(directory_excludes);
     log::trace!(
-        "SSH directory sync start: local_path={}, expanded_local_path={}, remote_path={}",
+        "SSH directory sync start: local_path={}, expanded_local_path={}, remote_path={}, directory_excludes={:?}",
         local_path,
         expanded,
-        remote_path
+        remote_path,
+        directory_excludes
     );
 
     if !Path::new(&expanded).exists() {
@@ -140,7 +196,14 @@ pub async fn sync_directory(
     session.exec_command(&mkdir_cmd).await?;
 
     // SFTP 递归上传到临时目录（upload_dir 内部会展开 ~ 和 $HOME）
-    session.upload_dir(&expanded, &tmp_remote_path).await?;
+    session
+        .upload_dir_with_excludes_and_progress(
+            &expanded,
+            &tmp_remote_path,
+            &directory_excludes,
+            current_file_reporter,
+        )
+        .await?;
 
     // 原子替换：rm 旧目录 + mv 临时目录到目标
     let swap_cmd = format!(
@@ -155,20 +218,22 @@ pub async fn sync_directory(
         return Err(format!("目录替换失败: {}", e));
     }
     log::trace!(
-        "SSH directory sync uploaded successfully: expanded_local_path={}, remote_path={}, tmp_remote_path={}",
+        "SSH directory sync uploaded successfully: expanded_local_path={}, remote_path={}, tmp_remote_path={}, directory_excludes={:?}",
         expanded,
         remote_path,
-        tmp_remote_path
+        tmp_remote_path,
+        directory_excludes
     );
 
     Ok(vec![format!("{} -> {}", local_path, remote_path)])
 }
 
 /// 同步符合 glob 模式的文件到远程
-pub async fn sync_pattern_files(
+pub async fn sync_pattern_files_with_progress(
     local_pattern: &str,
     remote_dir: &str,
     session: &SshSession,
+    current_file_reporter: Option<CurrentFileReporter<'_>>,
 ) -> Result<Vec<String>, String> {
     let expanded = expand_local_path(local_pattern)?;
     log::trace!(
@@ -214,6 +279,10 @@ pub async fn sync_pattern_files(
 
         let remote_dest = format!("{}/{}", remote_dir.trim_end_matches('/'), file_name);
 
+        if let Some(reporter) = current_file_reporter {
+            reporter(pattern_file_display_path(&expanded, file_path));
+        }
+
         match upload_file_via_sftp(&sftp, &file_str, &remote_dest).await {
             Ok(()) => {
                 synced.push(format!(
@@ -255,6 +324,14 @@ pub async fn sync_file_mapping(
     mapping: &SSHFileMapping,
     session: &SshSession,
 ) -> Result<Vec<String>, String> {
+    sync_file_mapping_with_progress(mapping, session, None).await
+}
+
+pub async fn sync_file_mapping_with_progress(
+    mapping: &SSHFileMapping,
+    session: &SshSession,
+    current_file_reporter: Option<CurrentFileReporter<'_>>,
+) -> Result<Vec<String>, String> {
     let kind = mapping_kind(mapping);
     log::trace!(
         "SSH sync mapping start: id={}, name={}, module={}, kind={}, local_path={}, remote_path={}",
@@ -267,11 +344,30 @@ pub async fn sync_file_mapping(
     );
 
     let result = if mapping.is_directory {
-        sync_directory(&mapping.local_path, &mapping.remote_path, session).await
+        sync_directory_with_progress(
+            &mapping.local_path,
+            &mapping.remote_path,
+            session,
+            &mapping.directory_excludes,
+            current_file_reporter,
+        )
+        .await
     } else if mapping.is_pattern {
-        sync_pattern_files(&mapping.local_path, &mapping.remote_path, session).await
+        sync_pattern_files_with_progress(
+            &mapping.local_path,
+            &mapping.remote_path,
+            session,
+            current_file_reporter,
+        )
+        .await
     } else {
-        sync_single_file(&mapping.local_path, &mapping.remote_path, session).await
+        sync_single_file_with_progress(
+            &mapping.local_path,
+            &mapping.remote_path,
+            session,
+            current_file_reporter,
+        )
+        .await
     };
 
     match &result {
@@ -553,5 +649,30 @@ pub async fn check_remote_symlink_exists(
     match session.exec_command(&command).await {
         Ok(output) => output.trim() == "yes",
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pattern_file_display_path;
+    use std::path::Path;
+
+    #[test]
+    fn pattern_file_display_path_uses_static_glob_root() {
+        let pattern = "/home/me/.config/opencode/*.mjs";
+        let file_path = Path::new("/home/me/.config/opencode/plugin.mjs");
+
+        assert_eq!(pattern_file_display_path(pattern, file_path), "plugin.mjs");
+    }
+
+    #[test]
+    fn pattern_file_display_path_preserves_nested_relative_path() {
+        let pattern = "/home/me/.config/opencode/**/*.mjs";
+        let file_path = Path::new("/home/me/.config/opencode/plugins/plugin.mjs");
+
+        assert_eq!(
+            pattern_file_display_path(pattern, file_path),
+            "plugins/plugin.mjs"
+        );
     }
 }

--- a/tauri/src/coding/ssh/types.rs
+++ b/tauri/src/coding/ssh/types.rs
@@ -4,6 +4,44 @@ use serde::{Deserialize, Serialize};
 pub use super::super::wsl::{SyncProgress, SyncResult};
 use crate::coding::runtime_location::WslDirectModuleStatus;
 
+pub const DEFAULT_DIRECTORY_EXCLUDES: &[&str] = &[
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    "cache",
+];
+
+pub fn default_directory_excludes() -> Vec<String> {
+    DEFAULT_DIRECTORY_EXCLUDES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect()
+}
+
+pub fn normalize_directory_excludes(excludes: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut normalized = Vec::new();
+
+    for exclude in excludes {
+        let name = exclude
+            .trim()
+            .trim_matches(|c| c == '/' || c == '\\')
+            .trim();
+        if name.is_empty() || name.contains('/') || name.contains('\\') {
+            continue;
+        }
+        if seen.insert(name.to_string()) {
+            normalized.push(name.to_string());
+        }
+    }
+
+    normalized
+}
+
 // ============================================================================
 // SSH Connection Types
 // ============================================================================
@@ -41,6 +79,8 @@ pub struct SSHFileMapping {
     pub enabled: bool,
     pub is_pattern: bool,
     pub is_directory: bool,
+    #[serde(default)]
+    pub directory_excludes: Vec<String>,
 }
 
 // ============================================================================
@@ -79,6 +119,36 @@ impl Default for SSHSyncConfig {
             last_sync_error: None,
             module_statuses: vec![],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_directory_excludes, normalize_directory_excludes};
+
+    #[test]
+    fn normalizes_directory_excludes_by_trimming_and_deduplicating() {
+        let input = vec![
+            " cache ".to_string(),
+            "cache/".to_string(),
+            "node_modules".to_string(),
+            "nested/cache".to_string(),
+            "".to_string(),
+        ];
+
+        assert_eq!(
+            normalize_directory_excludes(&input),
+            vec!["cache".to_string(), "node_modules".to_string()]
+        );
+    }
+
+    #[test]
+    fn default_directory_excludes_cover_common_generated_directories() {
+        let excludes = default_directory_excludes();
+        assert!(excludes.contains(&".git".to_string()));
+        assert!(excludes.contains(&".venv".to_string()));
+        assert!(excludes.contains(&"node_modules".to_string()));
+        assert!(excludes.contains(&"cache".to_string()));
     }
 }
 

--- a/tauri/src/coding/wsl/commands.rs
+++ b/tauri/src/coding/wsl/commands.rs
@@ -336,6 +336,7 @@ pub(super) async fn do_full_sync(
             current: 0,
             total: total_files,
             message: format!("文件同步: 0/{}", total_files),
+            current_file: None,
         },
     );
 
@@ -489,6 +490,7 @@ fn sync_mappings_with_progress(
                 current,
                 total,
                 message: format!("文件同步: {}/{} - {}", current, total, mapping.name),
+                current_file: None,
             },
         );
 

--- a/tauri/src/coding/wsl/mcp_sync.rs
+++ b/tauri/src/coding/wsl/mcp_sync.rs
@@ -101,6 +101,7 @@ pub async fn sync_mcp_to_wsl(state: &DbState, app: AppHandle) -> Result<(), Stri
             current: 1,
             total: 2,
             message: "MCP 同步: Claude Code...".to_string(),
+            current_file: None,
         },
     );
 
@@ -134,6 +135,7 @@ pub async fn sync_mcp_to_wsl(state: &DbState, app: AppHandle) -> Result<(), Stri
             current: 2,
             total: 2,
             message: "MCP 同步: OpenCode/Codex/Gemini CLI...".to_string(),
+            current_file: None,
         },
     );
 

--- a/tauri/src/coding/wsl/skills_sync.rs
+++ b/tauri/src/coding/wsl/skills_sync.rs
@@ -150,6 +150,7 @@ pub async fn sync_skills_to_wsl(state: &DbState, app: AppHandle) -> Result<(), S
             current: 0,
             total: total_skills,
             message: format!("Skills 同步: 0/{}", total_skills),
+            current_file: None,
         },
     );
 
@@ -195,6 +196,7 @@ pub async fn sync_skills_to_wsl(state: &DbState, app: AppHandle) -> Result<(), S
                     "Skills 同步: {}/{} - {}",
                     current_idx, total_skills, skill.name
                 ),
+                current_file: None,
             },
         );
 

--- a/tauri/src/coding/wsl/types.rs
+++ b/tauri/src/coding/wsl/types.rs
@@ -125,4 +125,7 @@ pub struct SyncProgress {
     pub total: u32,
     /// Overall progress message
     pub message: String,
+    /// Current file being uploaded within the current item, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_file: Option<String>,
 }

--- a/web/features/settings/components/SSHFileMappingModal.tsx
+++ b/web/features/settings/components/SSHFileMappingModal.tsx
@@ -8,9 +8,30 @@ import React, { useEffect } from 'react';
 import { Modal, Form, Input, Select, Switch, Space, Typography, Divider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { sshAddFileMapping, sshUpdateFileMapping } from '@/services/sshSyncApi';
+import { DEFAULT_SSH_DIRECTORY_EXCLUDES } from '@/types/sshsync';
 import type { SSHFileMapping } from '@/types/sshsync';
 
 const { Text } = Typography;
+
+const normalizeDirectoryExcludes = (values: unknown): string[] => {
+  const items = Array.isArray(values) ? values : [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const item of items) {
+    if (typeof item !== 'string') {
+      continue;
+    }
+    const name = item.trim().replace(/^[\\/]+|[\\/]+$/g, '').trim();
+    if (!name || name.includes('/') || name.includes('\\') || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    normalized.push(name);
+  }
+
+  return normalized;
+};
 
 interface SSHFileMappingModalProps {
   open: boolean;
@@ -21,13 +42,28 @@ interface SSHFileMappingModalProps {
 export const SSHFileMappingModal: React.FC<SSHFileMappingModalProps> = ({ open, onClose, mapping }) => {
   const { t } = useTranslation();
   const [form] = Form.useForm();
+  const isDirectory = Form.useWatch('isDirectory', form);
 
   const isEdit = mapping !== null;
+
+  const handleDirectoryModeChange = (checked: boolean) => {
+    if (!checked) {
+      return;
+    }
+
+    const currentExcludes = form.getFieldValue('directoryExcludes');
+    if (!Array.isArray(currentExcludes) || currentExcludes.length === 0) {
+      form.setFieldValue('directoryExcludes', [...DEFAULT_SSH_DIRECTORY_EXCLUDES]);
+    }
+  };
 
   useEffect(() => {
     if (open) {
       if (mapping && mapping.id) {
-        form.setFieldsValue(mapping);
+        form.setFieldsValue({
+          ...mapping,
+          directoryExcludes: mapping.directoryExcludes ?? [...DEFAULT_SSH_DIRECTORY_EXCLUDES],
+        });
       } else {
         form.resetFields();
         form.setFieldsValue({
@@ -35,6 +71,7 @@ export const SSHFileMappingModal: React.FC<SSHFileMappingModalProps> = ({ open, 
           enabled: true,
           isPattern: false,
           isDirectory: false,
+          directoryExcludes: mapping?.directoryExcludes ?? [...DEFAULT_SSH_DIRECTORY_EXCLUDES],
         });
       }
     }
@@ -48,6 +85,9 @@ export const SSHFileMappingModal: React.FC<SSHFileMappingModalProps> = ({ open, 
       const newMapping: SSHFileMapping = {
         ...values,
         id,
+        directoryExcludes: values.isDirectory
+          ? normalizeDirectoryExcludes(values.directoryExcludes)
+          : [],
       };
 
       if (isEdit && mapping?.id) {
@@ -144,8 +184,22 @@ export const SSHFileMappingModal: React.FC<SSHFileMappingModalProps> = ({ open, 
           valuePropName="checked"
           extra={t('settings.ssh.directoryModeHint')}
         >
-          <Switch />
+          <Switch onChange={handleDirectoryModeChange} />
         </Form.Item>
+
+        {isDirectory && (
+          <Form.Item
+            name="directoryExcludes"
+            label={t('settings.ssh.directoryExcludes')}
+            extra={t('settings.ssh.directoryExcludesHint')}
+          >
+            <Select
+              mode="tags"
+              tokenSeparators={[',', '\n']}
+              placeholder={t('settings.ssh.directoryExcludesPlaceholder')}
+            />
+          </Form.Item>
+        )}
       </Form>
     </Modal>
   );

--- a/web/features/settings/components/SSHSyncModal.tsx
+++ b/web/features/settings/components/SSHSyncModal.tsx
@@ -739,23 +739,21 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
                 />
                 {syncProgress.currentFile && (
                   <div style={{ marginTop: 4, minWidth: 0, maxWidth: '100%' }}>
-                    <Tooltip title={syncProgress.currentFile} placement="topLeft">
-                      <Text
-                        type="secondary"
-                        style={{
-                          display: 'block',
-                          maxWidth: '100%',
-                          fontSize: 12,
-                          whiteSpace: 'nowrap',
-                          overflow: 'hidden',
-                          textOverflow: 'clip',
-                        }}
-                      >
-                        {t('settings.ssh.progress.currentFile', {
-                          file: truncateTailPath(syncProgress.currentFile),
-                        })}
-                      </Text>
-                    </Tooltip>
+                    <Text
+                      type="secondary"
+                      style={{
+                        display: 'block',
+                        maxWidth: '100%',
+                        fontSize: 12,
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'clip',
+                      }}
+                    >
+                      {t('settings.ssh.progress.currentFile', {
+                        file: truncateTailPath(syncProgress.currentFile),
+                      })}
+                    </Text>
                   </div>
                 )}
               </div>

--- a/web/features/settings/components/SSHSyncModal.tsx
+++ b/web/features/settings/components/SSHSyncModal.tsx
@@ -9,9 +9,6 @@ import { Modal, Switch, Select, Button, List, Space, Typography, Alert, Spin, Ta
 import { CheckCircleOutlined, CloseCircleOutlined, ReloadOutlined, DeleteOutlined, EditOutlined, PlusOutlined, ClearOutlined, ApiOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { useSSHSync } from '@/features/settings/hooks/useSSHSync';
-import { useSettingsStore } from '@/stores';
-import { SSHConnectionModal } from './SSHConnectionModal';
-import { SSHFileMappingModal } from './SSHFileMappingModal';
 import {
   isBuiltInDefaultMappingName,
   translateDefaultMappingName,
@@ -26,8 +23,12 @@ import {
   sshDeleteConnection,
   sshSetActiveConnection,
 } from '@/services/sshSyncApi';
+import { useSettingsStore } from '@/stores';
+import { DEFAULT_SSH_DIRECTORY_EXCLUDES } from '@/types/sshsync';
 import type { SSHConnection, SSHFileMapping, SSHConnectionResult } from '@/types/sshsync';
 import type { WslDirectModuleStatus } from '@/types/wslsync';
+import { SSHConnectionModal } from './SSHConnectionModal';
+import { SSHFileMappingModal } from './SSHFileMappingModal';
 
 const { Text } = Typography;
 
@@ -53,6 +54,17 @@ const AUTH_METHOD_TAG_COLORS: Record<SSHConnection['authMethod'], string> = {
   key: 'blue',
   password: 'green',
   none: 'default',
+};
+
+const CURRENT_FILE_TAIL_MAX_LENGTH = 72;
+
+const truncateTailPath = (path: string, maxLength = CURRENT_FILE_TAIL_MAX_LENGTH) => {
+  if (path.length <= maxLength) {
+    return path;
+  }
+
+  const tailLength = Math.max(1, maxLength - 3);
+  return `...${path.slice(-tailLength)}`;
 };
 
 // Map sync module keys to visibleTabs keys
@@ -119,6 +131,13 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
   const getModuleStatus = useCallback((module: string): WslDirectModuleStatus | undefined => {
     return moduleStatusMap.get(module);
   }, [moduleStatusMap]);
+
+  const getDirectoryExcludes = (mapping: SSHFileMapping): string[] => {
+    if (!mapping.isDirectory) {
+      return [];
+    }
+    return mapping.directoryExcludes ?? [...DEFAULT_SSH_DIRECTORY_EXCLUDES];
+  };
 
   const getDisplayLocalPath = useCallback((mapping: SSHFileMapping) => {
     const status = getModuleStatus(mapping.module);
@@ -367,6 +386,7 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
       enabled: true,
       isPattern: false,
       isDirectory: false,
+      directoryExcludes: [...DEFAULT_SSH_DIRECTORY_EXCLUDES],
     };
     setEditingMapping(newMapping);
     setMappingModalOpen(true);
@@ -493,9 +513,35 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
                   </Space>
                 }
                 description={
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    {getDisplayLocalPath(item)} → {item.remotePath}
-                  </Text>
+                  <Space orientation="vertical" size={2}>
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {getDisplayLocalPath(item)} → {item.remotePath}
+                    </Text>
+                    {item.isDirectory && (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                        <Text type="secondary" style={{ fontSize: 12, flexShrink: 0 }}>
+                          {t('settings.ssh.directoryExcludes')}:
+                        </Text>
+                        {getDirectoryExcludes(item).length > 0 ? (
+                          <Space size={[4, 2]} wrap>
+                            {getDirectoryExcludes(item).map((exclude) => (
+                              <Tag
+                                key={exclude}
+                                color="default"
+                                style={{ marginInlineEnd: 0, fontSize: 11, lineHeight: '18px' }}
+                              >
+                                {exclude}
+                              </Tag>
+                            ))}
+                          </Space>
+                        ) : (
+                          <Text type="secondary" style={{ fontSize: 12 }}>
+                            {t('settings.ssh.noDirectoryExcludes')}
+                          </Text>
+                        )}
+                      </div>
+                    )}
+                  </Space>
                 }
               />
             </List.Item>
@@ -691,12 +737,33 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
                   size="small"
                   status="active"
                 />
+                {syncProgress.currentFile && (
+                  <div style={{ marginTop: 4, minWidth: 0, maxWidth: '100%' }}>
+                    <Tooltip title={syncProgress.currentFile} placement="topLeft">
+                      <Text
+                        type="secondary"
+                        style={{
+                          display: 'block',
+                          maxWidth: '100%',
+                          fontSize: 12,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'clip',
+                        }}
+                      >
+                        {t('settings.ssh.progress.currentFile', {
+                          file: truncateTailPath(syncProgress.currentFile),
+                        })}
+                      </Text>
+                    </Tooltip>
+                  </div>
+                )}
               </div>
             )}
             {status?.lastSyncError && (
               <Alert
                 type="error"
-                message={translateSyncMessage(status.lastSyncError, 'ssh', t)}
+                title={translateSyncMessage(status.lastSyncError, 'ssh', t)}
                 showIcon
                 style={{ marginTop: 12 }}
               />
@@ -704,10 +771,9 @@ export const SSHSyncModal: React.FC<SSHSyncModalProps> = ({ open, onClose }) => 
             {syncWarning && (
               <Alert
                 type="warning"
-                message={translateSyncMessage(syncWarning, 'ssh', t)}
+                title={translateSyncMessage(syncWarning, 'ssh', t)}
                 showIcon
-                closable
-                onClose={dismissSyncWarning}
+                closable={{ onClose: dismissSyncWarning }}
                 style={{ marginTop: 12 }}
               />
             )}

--- a/web/i18n/locales/en-US.json
+++ b/web/i18n/locales/en-US.json
@@ -536,6 +536,10 @@
 			"patternModeHint": "e.g., *.json",
 			"directoryMode": "Directory Mode",
 			"directoryModeHint": "Sync entire directory and its contents",
+			"directoryExcludes": "Excluded directories",
+			"directoryExcludesHint": "Directory mode only. Skips matching folder names recursively. Use Enter or comma to add names.",
+			"directoryExcludesPlaceholder": "e.g., cache, .venv, node_modules",
+			"noDirectoryExcludes": "No excluded directories",
 			"disabled": "Disabled",
 			"lastSyncTime": "Last Sync Time",
 			"never": "Never",
@@ -548,7 +552,8 @@
 				"preparingFiles": "Syncing files: 0/{{total}}",
 				"filesWithName": "Syncing files: {{current}}/{{total}} - {{name}}",
 				"preparingSkills": "Syncing skills: 0/{{total}}",
-				"skillsWithName": "Syncing skills: {{current}}/{{total}} - {{name}}"
+				"skillsWithName": "Syncing skills: {{current}}/{{total}} - {{name}}",
+				"currentFile": "Current file: {{file}}"
 			},
 			"autoSyncHint": "MCP servers and Skills for OpenCode, Claude, and Codex, and Skills for OpenClaw are automatically synced — no manual mapping needed.",
 			"indicator": {

--- a/web/i18n/locales/zh-CN.json
+++ b/web/i18n/locales/zh-CN.json
@@ -536,6 +536,10 @@
 			"patternModeHint": "如 *.json",
 			"directoryMode": "目录模式",
 			"directoryModeHint": "同步整个目录及其内容",
+			"directoryExcludes": "排除目录",
+			"directoryExcludesHint": "仅在目录模式生效。按目录名递归跳过，支持回车或逗号分隔。",
+			"directoryExcludesPlaceholder": "如 cache、.venv、node_modules",
+			"noDirectoryExcludes": "不排除目录",
 			"disabled": "已禁用",
 			"lastSyncTime": "上次同步时间",
 			"never": "从未同步",
@@ -548,7 +552,8 @@
 				"preparingFiles": "文件同步: 0/{{total}}",
 				"filesWithName": "文件同步: {{current}}/{{total}} - {{name}}",
 				"preparingSkills": "Skills 同步: 0/{{total}}",
-				"skillsWithName": "Skills 同步: {{current}}/{{total}} - {{name}}"
+				"skillsWithName": "Skills 同步: {{current}}/{{total}} - {{name}}",
+				"currentFile": "当前文件：{{file}}"
 			},
 			"autoSyncHint": "OpenCode、Claude、Codex 的 MCP 和 Skills，以及 OpenClaw 的 Skills 会在同步时自动处理，无需手动添加映射。",
 			"indicator": {

--- a/web/types/sshsync.ts
+++ b/web/types/sshsync.ts
@@ -26,6 +26,17 @@ export interface SSHConnection {
 /**
  * SSH file mapping (global, shared across all connections)
  */
+export const DEFAULT_SSH_DIRECTORY_EXCLUDES = [
+  '.git',
+  '.venv',
+  'venv',
+  'node_modules',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  'cache',
+] as const;
+
 export interface SSHFileMapping {
   id: string;
   name: string;
@@ -35,6 +46,7 @@ export interface SSHFileMapping {
   enabled: boolean;
   isPattern: boolean;
   isDirectory: boolean;
+  directoryExcludes: string[];
 }
 
 /**
@@ -43,6 +55,8 @@ export interface SSHFileMapping {
 export interface SSHSyncConfig {
   enabled: boolean;
   activeConnectionId: string;
+  syncMcp: boolean;
+  syncSkills: boolean;
   fileMappings: SSHFileMapping[];
   connections: SSHConnection[];
   lastSyncTime?: string;
@@ -90,4 +104,5 @@ export interface SyncProgress {
   current: number;
   total: number;
   message: string;
+  currentFile?: string;
 }

--- a/web/types/wslsync.ts
+++ b/web/types/wslsync.ts
@@ -95,4 +95,6 @@ export interface SyncProgress {
   total: number;
   /** Overall progress message */
   message: string;
+  /** Current file being uploaded within the current item, when available */
+  currentFile?: string;
 }


### PR DESCRIPTION
## 背景

SSH 目录同步之前会按“整目录上传”处理，像 Claude Code 插件目录这类运行时目录里会混入大量生成内容和缓存目录，例如 `cache/`、`.venv/`、`node_modules/` 等。实际同步时这些目录可能非常大，容易导致 SFTP 上传耗时过长甚至触发超时。

同时，原来的同步状态条只显示当前同步到哪个 file mapping，例如“文件同步: 2/14 - Claude Code 插件目录”，用户无法判断目录同步具体卡在哪个文件或子目录，排查超时原因不直观。

## 本次改动

- 为 SSH directory mapping 增加目录排除配置，默认排除常见生成/缓存目录：`.git`、`.venv`、`venv`、`node_modules`、`__pycache__`、`.pytest_cache`、`.mypy_cache`、`cache`。
- 兼容已有 SSH mapping：目录模式缺失排除配置时回填默认值，显式空数组仍表示“不排除目录”。
- 递归 SFTP 上传时在进入子目录前跳过被排除的目录，Skills SSH 独立同步链路也复用同一默认排除规则。
- SSH mapping 列表中用“排除目录:”标签行 + 灰色 tag 展示排除项，编辑 mapping 时可修改排除目录。
- SSH 同步进度事件新增当前文件信息，状态条展示当前正在同步的相对文件路径；长路径单行尾部省略，hover 可查看完整路径。
- 保持进度百分比语义不变，仍按 mapping / 阶段计数，不做目录内文件总数预扫描。

<img width="653" height="144" alt="image" src="https://github.com/user-attachments/assets/eaa3af99-30da-438d-a2ba-e3e266fb5772" />
<img width="548" height="754" alt="image" src="https://github.com/user-attachments/assets/c8e12528-d22c-4a4d-8cb1-b75859c97f8a" />
<img width="665" height="147" alt="image" src="https://github.com/user-attachments/assets/88bade44-23de-4379-8702-eb46a70b9d84" />
