### PR TITLE
fix(codex): 自动创建官方默认配置

### DIFF
--- a/tauri/src/coding/codex/AGENTS.md
+++ b/tauri/src/coding/codex/AGENTS.md
@@ -18,6 +18,7 @@
 - `auth.json` 与 `config.toml` 混有 Codex runtime 自有字段；AI Toolbox 只能改受管字段，不能整文件覆盖运行时状态。
 - `apply_config_internal` 统一负责写文件、更新 `is_applied`、发 `config-changed` 和 `wsl-sync-request-codex`。
 - Codex 官方订阅的模型下拉来源是共享模型目录，而不是 Codex 本地账号文件。远程目录不可用时使用内置兜底；账号 quota/plan 只影响可用性判断，不应阻断 provider 表单读取模型列表。
+- 当 provider 表为空且当前 Codex root 的 `auth.json` 明确包含官方登录态时，启动初始化和 provider 列表懒加载都会自动创建持久化 official 默认 provider；仅 API key 或 base_url 自定义配置不能走 official-only 自动导入。
 
 ## 关键流程
 

--- a/tauri/src/coding/codex/commands.rs
+++ b/tauri/src/coding/codex/commands.rs
@@ -6,8 +6,9 @@ use std::path::PathBuf;
 
 use super::adapter;
 use super::official_accounts::{
-    clear_all_codex_official_account_apply_status, codex_provider_has_official_accounts,
-    ensure_codex_provider_has_no_official_accounts, sync_codex_official_account_apply_status,
+    auth_has_official_runtime, clear_all_codex_official_account_apply_status,
+    codex_provider_has_official_accounts, ensure_codex_provider_has_no_official_accounts,
+    sync_codex_official_account_apply_status,
 };
 use super::plugin_ops;
 use super::plugin_state;
@@ -789,14 +790,23 @@ pub async fn reveal_codex_config_folder(
 // ============================================================================
 
 /// List all Codex providers ordered by sort_index
-/// If database is empty, returns a temporary provider loaded from local config files
+/// If database is empty, persists a local official login as the default provider before
+/// falling back to a temporary provider loaded from local config files.
 #[tauri::command]
 pub async fn list_codex_providers(
     state: tauri::State<'_, SqliteDbState>,
 ) -> Result<Vec<CodexProvider>, String> {
-    let db = state.db();
+    list_codex_providers_for_db(state.db()).await
+}
 
-    let providers = list_codex_providers_from_sqlite(db)?;
+pub async fn list_codex_providers_for_db(
+    db: &crate::db::SqliteDbState,
+) -> Result<Vec<CodexProvider>, String> {
+    let mut providers = list_codex_providers_from_sqlite(db)?;
+    if providers.is_empty() {
+        import_codex_default_provider_from_local_files(db, true).await?;
+        providers = list_codex_providers_from_sqlite(db)?;
+    }
     if providers.is_empty() {
         if let Ok(temp_provider) = load_temp_provider_from_files_with_db(Some(db)).await {
             return Ok(vec![temp_provider]);
@@ -807,9 +817,9 @@ pub async fn list_codex_providers(
 
 /// 修复损坏的 Codex provider 数据
 /// This is used when the database is empty and we want to show the local config
-async fn load_temp_provider_from_files_with_db(
+async fn load_local_codex_provider_snapshot(
     db: Option<&crate::db::SqliteDbState>,
-) -> Result<CodexProvider, String> {
+) -> Result<(serde_json::Value, serde_json::Value, String), String> {
     let root_dir = if let Some(db) = db {
         get_codex_root_dir_from_db_async(db).await?
     } else {
@@ -822,7 +832,6 @@ async fn load_temp_provider_from_files_with_db(
         return Err("No config files found".to_string());
     }
 
-    // Read auth.json (optional)
     let auth: serde_json::Value = if auth_path.exists() {
         let auth_content = fs::read_to_string(&auth_path)
             .map_err(|e| format!("Failed to read auth.json: {}", e))?;
@@ -832,14 +841,12 @@ async fn load_temp_provider_from_files_with_db(
         serde_json::json!({})
     };
 
-    // Read config.toml (optional)
     let config_toml = if config_path.exists() {
         fs::read_to_string(&config_path).unwrap_or_default()
     } else {
         String::new()
     };
 
-    // Build settings_config
     let settings = serde_json::json!({
         "auth": auth,
         "config": config_toml
@@ -851,6 +858,18 @@ async fn load_temp_provider_from_files_with_db(
     };
     let provider_settings =
         extract_provider_settings_for_storage(&settings, stored_common_toml.as_deref())?;
+    let settings_config = serde_json::to_string(&provider_settings)
+        .map_err(|error| format!("Failed to serialize provider settings: {error}"))?;
+
+    Ok((auth, provider_settings, settings_config))
+}
+
+/// 修复损坏的 Codex provider 数据
+/// This is used when the database is empty and we want to show the local config
+async fn load_temp_provider_from_files_with_db(
+    db: Option<&crate::db::SqliteDbState>,
+) -> Result<CodexProvider, String> {
+    let (_, provider_settings, settings_config) = load_local_codex_provider_snapshot(db).await?;
     let category = infer_codex_provider_category_from_settings(&provider_settings);
 
     let now = Local::now().to_rfc3339();
@@ -858,7 +877,7 @@ async fn load_temp_provider_from_files_with_db(
         id: "__local__".to_string(), // Special ID to indicate this is from local files
         name: "default".to_string(),
         category,
-        settings_config: serde_json::to_string(&provider_settings).unwrap_or_default(),
+        settings_config,
         source_provider_id: None,
         website_url: None,
         notes: None,
@@ -871,6 +890,80 @@ async fn load_temp_provider_from_files_with_db(
         created_at: now.clone(),
         updated_at: now,
     })
+}
+
+pub async fn import_codex_default_provider_from_local_files(
+    db: &crate::db::SqliteDbState,
+    official_only: bool,
+) -> Result<Option<CodexProvider>, String> {
+    if db.with_conn(|conn| db_count(conn, DbTable::CodexProvider))? > 0 {
+        return Ok(None);
+    }
+
+    let (auth, provider_settings, settings_config) =
+        match load_local_codex_provider_snapshot(Some(db)).await {
+            Ok(snapshot) => snapshot,
+            Err(error) if error == "No config files found" => return Ok(None),
+            Err(error) => return Err(error),
+        };
+    let category = infer_codex_provider_category_from_settings(&provider_settings);
+    if official_only && (category != "official" || !auth_has_official_runtime(&auth)) {
+        return Ok(None);
+    }
+
+    let now = Local::now().to_rfc3339();
+    let content = CodexProviderContent {
+        name: "默认配置".to_string(),
+        category,
+        settings_config,
+        source_provider_id: None,
+        website_url: None,
+        notes: Some("从配置文件自动导入".to_string()),
+        icon: None,
+        icon_color: None,
+        sort_index: Some(0),
+        meta: None,
+        is_applied: true,
+        is_disabled: false,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+
+    let provider_id = db_new_id();
+    let inserted = db.with_conn(|conn| {
+        if db_count(conn, DbTable::CodexProvider)? > 0 {
+            return Ok(false);
+        }
+        db_put(
+            conn,
+            DbTable::CodexProvider,
+            &provider_id,
+            &adapter::to_db_value_provider(&content),
+        )?;
+        Ok(true)
+    })?;
+
+    if !inserted {
+        return Ok(None);
+    }
+
+    Ok(Some(CodexProvider {
+        id: provider_id,
+        name: content.name,
+        category: content.category,
+        settings_config: content.settings_config,
+        source_provider_id: content.source_provider_id,
+        website_url: content.website_url,
+        notes: content.notes,
+        icon: content.icon,
+        icon_color: content.icon_color,
+        sort_index: content.sort_index,
+        meta: content.meta,
+        is_applied: content.is_applied,
+        is_disabled: content.is_disabled,
+        created_at: content.created_at,
+        updated_at: content.updated_at,
+    }))
 }
 
 async fn get_codex_common_toml(db: &crate::db::SqliteDbState) -> Result<Option<String>, String> {
@@ -994,7 +1087,30 @@ fn config_contains_managed_codex_provider(config_toml: &str) -> bool {
         Err(_) => return false,
     };
 
+    selected_codex_provider_has_base_url(parsed_document.as_table())
+}
+
+fn config_contains_managed_base_url(config_toml: &str) -> bool {
+    let trimmed_config = config_toml.trim();
+    if trimmed_config.is_empty() {
+        return false;
+    }
+
+    let parsed_document = match parse_toml_document(trimmed_config, "provider config") {
+        Ok(document) => document,
+        Err(_) => return false,
+    };
+
     let root_table = parsed_document.as_table();
+    root_table
+        .get("base_url")
+        .and_then(|item| item.as_str())
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        || selected_codex_provider_has_base_url(root_table)
+}
+
+fn selected_codex_provider_has_base_url(root_table: &toml_edit::Table) -> bool {
     let provider_key = root_table
         .get("model_provider")
         .and_then(|item| item.as_str())
@@ -1035,7 +1151,7 @@ pub(super) fn infer_codex_provider_category_from_settings(
     let has_managed_base_url = provider_settings
         .get("config")
         .and_then(|value| value.as_str())
-        .map(config_contains_managed_codex_provider)
+        .map(config_contains_managed_base_url)
         .unwrap_or(false);
 
     if !has_managed_api_key && !has_managed_base_url {
@@ -3017,66 +3133,11 @@ pub async fn save_codex_local_config(
 pub async fn init_codex_provider_from_settings(
     db: &crate::db::SqliteDbState,
 ) -> Result<(), String> {
-    let has_providers = db.with_conn(|conn| db_count(conn, DbTable::CodexProvider))? > 0;
-    if has_providers {
-        return Ok(());
+    if import_codex_default_provider_from_local_files(db, false)
+        .await?
+        .is_some()
+    {
+        println!("✅ Imported Codex settings as default provider");
     }
-
-    // Check if config files exist
-    let root_dir = get_codex_root_dir_without_db()?;
-    let auth_path = root_dir.join("auth.json");
-    let config_path = root_dir.join("config.toml");
-    if !auth_path.exists() && !config_path.exists() {
-        return Ok(());
-    }
-
-    // Read auth.json (optional)
-    let auth: serde_json::Value = if auth_path.exists() {
-        let auth_content = fs::read_to_string(&auth_path)
-            .map_err(|e| format!("Failed to read auth.json: {}", e))?;
-        serde_json::from_str(&auth_content)
-            .map_err(|e| format!("Failed to parse auth.json: {}", e))?
-    } else {
-        serde_json::json!({})
-    };
-
-    // Read config.toml (optional)
-    let config_toml = if config_path.exists() {
-        fs::read_to_string(&config_path).unwrap_or_default()
-    } else {
-        String::new()
-    };
-
-    // Build settings_config
-    let settings = serde_json::json!({
-        "auth": auth,
-        "config": config_toml
-    });
-    let common_toml = get_codex_common_toml(db).await?;
-    let provider_settings =
-        extract_provider_settings_for_storage(&settings, common_toml.as_deref())?;
-
-    let now = Local::now().to_rfc3339();
-    let content = CodexProviderContent {
-        name: "默认配置".to_string(),
-        category: infer_codex_provider_category_from_settings(&provider_settings),
-        settings_config: serde_json::to_string(&provider_settings).unwrap_or_default(),
-        source_provider_id: None,
-        website_url: None,
-        notes: Some("从配置文件自动导入".to_string()),
-        icon: None,
-        icon_color: None,
-        sort_index: Some(0),
-        meta: None,
-        is_applied: true,
-        is_disabled: false,
-        created_at: now.clone(),
-        updated_at: now,
-    };
-
-    let provider_id = db_new_id();
-    put_codex_provider_to_sqlite(db, &provider_id, &content)?;
-
-    println!("✅ Imported Codex settings as default provider");
     Ok(())
 }

--- a/tauri/src/coding/codex/official_accounts.rs
+++ b/tauri/src/coding/codex/official_accounts.rs
@@ -414,7 +414,7 @@ fn build_auth_snapshot(
     Ok(Value::Object(auth_object))
 }
 
-fn auth_has_official_runtime(auth: &Value) -> bool {
+pub(super) fn auth_has_official_runtime(auth: &Value) -> bool {
     let auth_mode = auth
         .get("auth_mode")
         .and_then(|value| value.as_str())
@@ -1150,23 +1150,30 @@ fn assign_provider_id(
     account
 }
 
+pub async fn list_codex_official_accounts_for_provider(
+    db: &crate::db::SqliteDbState,
+    provider_id: &str,
+) -> Result<Vec<CodexOfficialAccount>, String> {
+    let provider = query_provider(db, provider_id).await?;
+    let mut accounts = list_persisted_official_accounts(db, provider_id).await?;
+    let local_auth = read_auth_json_from_disk(Some(db)).await?;
+    if provider.category == "official" && should_show_virtual_local_account(&accounts, &local_auth)
+    {
+        accounts.push(assign_provider_id(
+            build_virtual_local_account(&local_auth),
+            provider_id,
+        ));
+    }
+    Ok(accounts)
+}
+
 #[tauri::command]
 pub async fn list_codex_official_accounts(
     state: tauri::State<'_, SqliteDbState>,
     provider_id: String,
 ) -> Result<Vec<CodexOfficialAccount>, String> {
     let db = state.db();
-    let provider = query_provider(&db, &provider_id).await?;
-    let mut accounts = list_persisted_official_accounts(&db, &provider_id).await?;
-    let local_auth = read_auth_json_from_disk(Some(&db)).await?;
-    if provider.category == "official" && should_show_virtual_local_account(&accounts, &local_auth)
-    {
-        accounts.push(assign_provider_id(
-            build_virtual_local_account(&local_auth),
-            &provider_id,
-        ));
-    }
-    Ok(accounts)
+    list_codex_official_accounts_for_provider(&db, &provider_id).await
 }
 
 #[tauri::command]
@@ -1451,6 +1458,29 @@ pub async fn copy_codex_official_account_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auth_has_official_runtime_requires_auth_mode_and_both_tokens() {
+        assert!(auth_has_official_runtime(&serde_json::json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "access-token",
+                "refresh_token": "refresh-token"
+            }
+        })));
+
+        assert!(!auth_has_official_runtime(&serde_json::json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "access-token"
+            }
+        })));
+        assert!(!auth_has_official_runtime(&serde_json::json!({
+            "OPENAI_API_KEY": "sk-test",
+            "auth_mode": "apikey"
+        })));
+        assert!(!auth_has_official_runtime(&serde_json::json!({})));
+    }
 
     #[test]
     fn parse_usage_snapshot_free_treats_primary_week_window_as_weekly_limit() {

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1049,6 +1049,9 @@ pub fn run() {
                 {
                     warn!("运行时路径缓存初始化失败: {}", e);
                 }
+                if let Err(e) = coding::codex::init_codex_provider_from_settings(&db_state).await {
+                    warn!("Codex 默认配置初始化失败: {}", e);
+                }
 
                 app.manage(db_state);
                 info!("SQLite 主数据库状态已注册到应用");

--- a/tauri/tests/coding.rs
+++ b/tauri/tests/coding.rs
@@ -2,6 +2,8 @@
 mod claude_code_plugin_metadata_sync;
 #[path = "coding/claude_code/settings_merge.rs"]
 mod claude_code_settings_merge;
+#[path = "coding/codex/default_official_config.rs"]
+mod codex_default_official_config;
 #[path = "coding/mcp/command_normalize.rs"]
 mod mcp_command_normalize;
 #[path = "coding/oh_my_opencode_slim/adapter.rs"]

--- a/tauri/tests/coding/codex/default_official_config.rs
+++ b/tauri/tests/coding/codex/default_official_config.rs
@@ -1,0 +1,259 @@
+use ai_toolbox_lib::coding::codex::{
+    adapter, import_codex_default_provider_from_local_files, init_codex_provider_from_settings,
+    list_codex_providers_for_db,
+};
+use ai_toolbox_lib::coding::runtime_location;
+use ai_toolbox_lib::db::helpers::{db_count, db_get, db_put};
+use ai_toolbox_lib::db::schema::DbTable;
+use ai_toolbox_lib::db::sqlite_state::SqliteDbState;
+use serde_json::{json, Value};
+use std::sync::{Mutex, OnceLock};
+use tempfile::TempDir;
+
+fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Runtime::new()
+        .expect("tokio runtime")
+        .block_on(future)
+}
+
+fn codex_runtime_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("codex runtime lock")
+}
+
+struct TestCodexRoot {
+    _temp_dir: TempDir,
+    root_dir: std::path::PathBuf,
+}
+
+impl TestCodexRoot {
+    fn new() -> Self {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let root_dir = temp_dir.path().join("codex-root");
+        std::fs::create_dir_all(&root_dir).expect("create codex root");
+        Self {
+            _temp_dir: temp_dir,
+            root_dir,
+        }
+    }
+
+    fn write_auth(&self, auth: Value) {
+        let content = serde_json::to_string_pretty(&auth).expect("serialize auth");
+        std::fs::write(self.root_dir.join("auth.json"), content).expect("write auth");
+    }
+
+    fn write_config(&self, config: &str) {
+        std::fs::write(self.root_dir.join("config.toml"), config).expect("write config");
+    }
+}
+
+fn db_with_codex_root(root_dir: &std::path::Path) -> SqliteDbState {
+    let db = SqliteDbState::in_memory_for_test().expect("sqlite state");
+    db.with_conn(|conn| {
+        db_put(
+            conn,
+            DbTable::CodexCommonConfig,
+            "common",
+            &adapter::to_db_value_common("", Some(&root_dir.to_string_lossy())),
+        )
+        .map(|_| ())
+    })
+    .expect("save codex common config");
+    block_on(runtime_location::refresh_runtime_location_cache_for_module_async(&db, "codex"))
+        .expect("refresh codex runtime cache");
+    db
+}
+
+fn official_auth() -> Value {
+    json!({
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "id_token": "header.eyJlbWFpbCI6InJhbHBoQGV4YW1wbGUuY29tIiwiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS9hdXRoIjp7ImNoYXRncHRfcGxhbl90eXBlIjoicHJvIiwiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF8xMjMifX0.signature",
+            "account_id": "acct_123"
+        },
+        "last_refresh": "2026-05-21T00:00:00Z"
+    })
+}
+
+#[test]
+fn imports_official_local_auth_as_persisted_default_provider() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(official_auth());
+    root.write_config("model = \"gpt-5.2\"\n");
+    let db = db_with_codex_root(&root.root_dir);
+
+    let imported = block_on(import_codex_default_provider_from_local_files(&db, true))
+        .expect("import official provider")
+        .expect("provider imported");
+
+    assert_ne!(imported.id, "__local__");
+    assert_eq!(imported.name, "默认配置");
+    assert_eq!(imported.category, "official");
+    assert!(imported.is_applied);
+
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 1);
+
+    let stored = db
+        .with_conn(|conn| db_get(conn, DbTable::CodexProvider, &imported.id))
+        .expect("get provider")
+        .expect("stored provider");
+    assert_eq!(stored["category"], "official");
+    assert_eq!(stored["is_applied"], true);
+}
+
+#[test]
+fn startup_and_lazy_import_are_idempotent() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(official_auth());
+    let db = db_with_codex_root(&root.root_dir);
+
+    block_on(init_codex_provider_from_settings(&db)).expect("startup import");
+    let second =
+        block_on(import_codex_default_provider_from_local_files(&db, true)).expect("lazy import");
+
+    assert!(second.is_none());
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn does_not_create_provider_without_local_config_files() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    let db = db_with_codex_root(&root.root_dir);
+
+    let imported = block_on(import_codex_default_provider_from_local_files(&db, true))
+        .expect("empty local config import should be a no-op");
+
+    assert!(imported.is_none());
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn official_only_import_does_not_import_custom_api_key_config() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(json!({
+        "OPENAI_API_KEY": "sk-test",
+        "auth_mode": "apikey"
+    }));
+    root.write_config(
+        r#"model_provider = "custom"
+model = "gpt-test"
+[model_providers.custom]
+name = "custom"
+base_url = "https://example.invalid/v1"
+"#,
+    );
+    let db = db_with_codex_root(&root.root_dir);
+
+    let imported = block_on(import_codex_default_provider_from_local_files(&db, true))
+        .expect("custom official-only import");
+
+    assert!(imported.is_none());
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn official_only_import_does_not_import_custom_top_level_base_url_config() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_config("model = \"gpt-test\"\nbase_url = \"https://example.invalid/v1\"\n");
+    let db = db_with_codex_root(&root.root_dir);
+
+    let imported = block_on(import_codex_default_provider_from_local_files(&db, true))
+        .expect("custom base-url official-only import");
+
+    assert!(imported.is_none());
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn lazy_list_imports_official_auth_as_persisted_provider_without_local_fallback_id() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(official_auth());
+    let db = db_with_codex_root(&root.root_dir);
+
+    let providers = block_on(list_codex_providers_for_db(&db)).expect("list providers");
+
+    assert_eq!(providers.len(), 1);
+    assert_ne!(providers[0].id, "__local__");
+    assert_eq!(providers[0].category, "official");
+    assert!(providers[0].is_applied);
+
+    let second_list = block_on(list_codex_providers_for_db(&db)).expect("list providers again");
+    assert_eq!(second_list.len(), 1);
+    assert_eq!(second_list[0].id, providers[0].id);
+}
+
+#[test]
+fn lazy_list_keeps_custom_local_config_as_temporary_provider() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(json!({
+        "OPENAI_API_KEY": "sk-test",
+        "auth_mode": "apikey"
+    }));
+    root.write_config(
+        r#"model_provider = "custom"
+model = "gpt-test"
+[model_providers.custom]
+name = "custom"
+base_url = "https://example.invalid/v1"
+"#,
+    );
+    let db = db_with_codex_root(&root.root_dir);
+
+    let providers = block_on(list_codex_providers_for_db(&db)).expect("list providers");
+
+    assert_eq!(providers.len(), 1);
+    assert_eq!(providers[0].id, "__local__");
+    assert_eq!(providers[0].category, "custom");
+    let count = db
+        .with_conn(|conn| db_count(conn, DbTable::CodexProvider))
+        .expect("count providers");
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn command_level_e2e_imported_provider_unlocks_official_local_account() {
+    let _lock = codex_runtime_lock();
+    let root = TestCodexRoot::new();
+    root.write_auth(official_auth());
+    let db = db_with_codex_root(&root.root_dir);
+
+    let providers = block_on(list_codex_providers_for_db(&db)).expect("list providers");
+    let provider = providers.first().expect("provider imported by lazy list");
+
+    let accounts = block_on(
+        ai_toolbox_lib::coding::codex::list_codex_official_accounts_for_provider(&db, &provider.id),
+    )
+    .expect("list official accounts");
+
+    assert_eq!(accounts.len(), 1);
+    assert_ne!(provider.id, "__local__");
+    assert_eq!(accounts[0].id, "__local__");
+    assert_eq!(accounts[0].provider_id, provider.id);
+    assert_eq!(accounts[0].email.as_deref(), Some("ralph@example.com"));
+}


### PR DESCRIPTION
## 摘要

- 当 Codex provider 表为空且本地 `auth.json` 已有官方登录态时，自动创建持久化 official 默认 provider
- 在启动初始化和 provider 列表懒加载两处兜底，避免页面只拿到 `__local__` 导致官方账号链路不可用
- 补充命令级 E2E 测试，覆盖官方登录态导入、自定义配置不误判、幂等和 official accounts 链路

## 测试

- [x] `cd tauri && cargo test --test coding codex_default_official_config`
- [x] `cd tauri && cargo test --test coding`
- [x] `git diff --check`
- [x] 本地手测：清空 Toolbox Codex 配置后启动新版本，确认无明显问题