### PR TITLE
fix(wsl): resolve reconnection status display flickering

### DIFF
--- a/tauri/src/coding/wsl/commands.rs
+++ b/tauri/src/coding/wsl/commands.rs
@@ -30,18 +30,11 @@ pub fn wsl_detect() -> WSLDetectResult {
 /// Check if a specific WSL distro is available
 #[tauri::command]
 pub fn wsl_check_distro(distro: String) -> WSLErrorResult {
-    match sync::get_wsl_distros() {
-        Ok(distros) => {
-            let available = distros.contains(&distro);
-            WSLErrorResult {
-                available,
-                error: if available {
-                    None
-                } else {
-                    Some(format!("Distro '{}' not found", distro))
-                },
-            }
-        }
+    match sync::get_effective_distro(&distro) {
+        Ok(_) => WSLErrorResult {
+            available: true,
+            error: None,
+        },
         Err(e) => WSLErrorResult {
             available: false,
             error: Some(e),
@@ -52,7 +45,10 @@ pub fn wsl_check_distro(distro: String) -> WSLErrorResult {
 /// Get running state of a specific WSL distro
 #[tauri::command]
 pub fn wsl_get_distro_state(distro: String) -> String {
-    sync::get_wsl_distro_state(&distro)
+    match sync::get_effective_distro(&distro) {
+        Ok(effective_distro) => sync::get_wsl_distro_state(&effective_distro),
+        Err(_) => "Unknown".to_string(),
+    }
 }
 
 // ============================================================================
@@ -799,8 +795,10 @@ pub fn wsl_open_terminal(distro: String) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+    let effective_distro = sync::get_effective_distro(&distro)?;
+
     std::process::Command::new("cmd")
-        .args(["/c", "start", "wsl", "-d", &distro, "--cd", "~"])
+        .args(["/c", "start", "wsl", "-d", &effective_distro, "--cd", "~"])
         .creation_flags(CREATE_NO_WINDOW)
         .spawn()
         .map_err(|e| format!("Failed to open WSL terminal: {}", e))?;
@@ -821,9 +819,18 @@ pub fn wsl_open_folder(distro: String) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+    let effective_distro = sync::get_effective_distro(&distro)?;
+
     // Get actual home directory from WSL (handles root user whose home is /root, not /home/root)
     let output = std::process::Command::new("wsl")
-        .args(["-d", &distro, "--exec", "bash", "-c", "echo $HOME"])
+        .args([
+            "-d",
+            &effective_distro,
+            "--exec",
+            "bash",
+            "-c",
+            "echo $HOME",
+        ])
         .creation_flags(CREATE_NO_WINDOW)
         .output()
         .map_err(|e| format!("Failed to get WSL home directory: {}", e))?;
@@ -835,7 +842,7 @@ pub fn wsl_open_folder(distro: String) -> Result<(), String> {
 
     // Convert WSL path (e.g. /root or /home/user) to UNC path: \\wsl$\<distro>\root or \\wsl$\<distro>\home\user
     let home_unix = home_dir.replace('/', "\\");
-    let wsl_path = format!(r"\\wsl$\{}{}", distro, home_unix);
+    let wsl_path = format!(r"\\wsl$\{}{}", effective_distro, home_unix);
     std::process::Command::new("explorer.exe")
         .arg(&wsl_path)
         .creation_flags(CREATE_NO_WINDOW)

--- a/web/features/settings/components/WSLSyncModal.tsx
+++ b/web/features/settings/components/WSLSyncModal.tsx
@@ -181,13 +181,13 @@ export const WSLSyncModal: React.FC<WSLSyncModalProps> = ({ open, onClose }) => 
     try {
       const result = await detect();
       setDistros(result.distros);
-      if (result.distros.length > 0 && !result.distros.includes(distro)) {
-        setDistro(result.distros[0]);
+      if (result.distros.length > 0) {
+        setDistro((current) => current || result.distros[0]);
       }
     } catch (error) {
       console.error('Failed to detect WSL:', error);
     }
-  }, [detect, distro]);
+  }, [detect]);
 
   useEffect(() => {
     if (open) {

--- a/web/features/settings/hooks/useWSLSync.ts
+++ b/web/features/settings/hooks/useWSLSync.ts
@@ -1,10 +1,14 @@
 /**
  * WSL Sync Hook
  *
- * Manages WSL sync configuration and operations
+ * Manages WSL sync configuration and operations.
+ *
+ * NOTE: This hook is used by both MainLayout (for status indicator) and
+ * WSLSyncModal (for configuration UI). Event listeners are set up only once
+ * using module-level state to avoid duplicate API calls.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import type {
   WSLSyncConfig,
@@ -26,6 +30,25 @@ import {
 } from '@/services/wslSyncApi';
 import { useSettingsStore } from '@/stores';
 
+// Module-level state to share across hook instances and avoid duplicate listeners
+let globalConfig: WSLSyncConfig | null = null;
+let globalStatus: WSLStatusResult | null = null;
+let globalLoading = false;
+let globalLoadError: string | null = null;
+let globalSyncWarning: string | null = null;
+let globalSyncProgress: SyncProgress | null = null;
+const configListeners = new Set<(config: WSLSyncConfig | null) => void>();
+const statusListeners = new Set<(status: WSLStatusResult | null) => void>();
+const loadingListeners = new Set<(loading: boolean) => void>();
+const loadErrorListeners = new Set<(error: string | null) => void>();
+const syncWarningListeners = new Set<(warning: string | null) => void>();
+const syncProgressListeners = new Set<(progress: SyncProgress | null) => void>();
+let listenersSetup = false;
+let configLoadPromise: Promise<void> | null = null;
+let statusLoadPromise: Promise<void> | null = null;
+let configRequestSeq = 0;
+let statusRequestSeq = 0;
+
 // Map visibleTabs keys to sync module keys
 const TAB_TO_MODULE: Record<string, string> = {
   opencode: 'opencode',
@@ -36,32 +59,55 @@ const TAB_TO_MODULE: Record<string, string> = {
 };
 const ALL_CODING_MODULES = ['opencode', 'claude', 'codex', 'geminicli', 'openclaw'];
 
-export function useWSLSync() {
-  const [config, setConfig] = useState<WSLSyncConfig | null>(null);
-  const [status, setStatus] = useState<WSLStatusResult | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [syncing, setSyncing] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [syncWarning, setSyncWarning] = useState<string | null>(null);
-  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
+const notify = <T,>(listeners: Set<(value: T) => void>, value: T) => {
+  listeners.forEach((listener) => listener(value));
+};
 
-  // Flag to prevent reload after we just saved defaults
-  const skipNextReload = useRef(false);
+const setGlobalConfig = (value: WSLSyncConfig | null) => {
+  globalConfig = value;
+  notify(configListeners, value);
+};
 
-  /**
-   * Load WSL sync configuration
-   */
-  const loadConfig = useCallback(async () => {
-    // Skip if we just saved defaults to prevent loop
-    if (skipNextReload.current) {
-      skipNextReload.current = false;
-      return;
-    }
+const setGlobalStatus = (value: WSLStatusResult | null) => {
+  globalStatus = value;
+  notify(statusListeners, value);
+};
 
+const setGlobalLoading = (value: boolean) => {
+  globalLoading = value;
+  notify(loadingListeners, value);
+};
+
+const setGlobalLoadError = (value: string | null) => {
+  globalLoadError = value;
+  notify(loadErrorListeners, value);
+};
+
+const setGlobalSyncWarning = (value: string | null) => {
+  globalSyncWarning = value;
+  notify(syncWarningListeners, value);
+};
+
+const setGlobalSyncProgress = (value: SyncProgress | null) => {
+  globalSyncProgress = value;
+  notify(syncProgressListeners, value);
+};
+
+const loadConfigShared = async (force = false) => {
+  if (configLoadPromise && !force) {
+    return configLoadPromise;
+  }
+
+  const requestId = ++configRequestSeq;
+  const promise = (async () => {
     try {
-      setLoading(true);
-      setLoadError(null);
+      setGlobalLoading(true);
+      setGlobalLoadError(null);
       const data = await wslGetConfig();
+
+      if (requestId !== configRequestSeq) {
+        return;
+      }
 
       // If no file mappings exist, initialize with defaults
       if (!data.fileMappings || data.fileMappings.length === 0) {
@@ -70,33 +116,140 @@ export function useWSLSync() {
           ...data,
           fileMappings: defaultMappings,
         };
-        // Set flag to skip the next reload triggered by save
-        skipNextReload.current = true;
         await wslSaveConfig(defaultConfig);
-        setConfig(defaultConfig);
+        if (requestId === configRequestSeq) {
+          setGlobalConfig(defaultConfig);
+        }
       } else {
-        setConfig(data);
+        setGlobalConfig(data);
       }
     } catch (error) {
       console.error('Failed to load WSL config:', error);
-      setLoadError(error instanceof Error ? error.message : String(error));
+      if (requestId === configRequestSeq) {
+        setGlobalLoadError(error instanceof Error ? error.message : String(error));
+      }
     } finally {
-      setLoading(false);
+      if (requestId === configRequestSeq) {
+        setGlobalLoading(false);
+        configLoadPromise = null;
+      }
     }
+  })();
+
+  configLoadPromise = promise;
+  return promise;
+};
+
+const loadStatusShared = async (force = false) => {
+  if (statusLoadPromise && !force) {
+    return statusLoadPromise;
+  }
+
+  const requestId = ++statusRequestSeq;
+  const promise = (async () => {
+    try {
+      setGlobalLoadError(null);
+      const data = await wslGetStatus();
+      if (requestId === statusRequestSeq) {
+        setGlobalStatus(data);
+      }
+    } catch (error) {
+      console.error('Failed to load WSL status:', error);
+      if (requestId === statusRequestSeq) {
+        setGlobalLoadError(error instanceof Error ? error.message : String(error));
+      }
+    } finally {
+      if (requestId === statusRequestSeq) {
+        statusLoadPromise = null;
+      }
+    }
+  })();
+
+  statusLoadPromise = promise;
+  return promise;
+};
+
+const setupWslEventListeners = () => {
+  if (listenersSetup) return;
+  listenersSetup = true;
+
+  listen('wsl-config-changed', () => {
+    loadConfigShared(true);
+    loadStatusShared(true);
+  }).catch((error) => {
+    listenersSetup = false;
+    console.error('Failed to listen to WSL config changes:', error);
+  });
+
+  listen<SyncResult>('wsl-sync-completed', () => {
+    loadStatusShared(true);
+    setGlobalSyncProgress(null);
+  }).catch((error) => {
+    listenersSetup = false;
+    console.error('Failed to listen to WSL sync completion:', error);
+  });
+
+  listen<string>('wsl-sync-warning', (event) => {
+    setGlobalSyncWarning(event.payload);
+  }).catch((error) => {
+    listenersSetup = false;
+    console.error('Failed to listen to WSL sync warnings:', error);
+  });
+
+  listen<SyncProgress>('wsl-sync-progress', (event) => {
+    setGlobalSyncProgress(event.payload);
+  }).catch((error) => {
+    listenersSetup = false;
+    console.error('Failed to listen to WSL sync progress:', error);
+  });
+};
+
+export function useWSLSync() {
+  const [config, setConfig] = useState<WSLSyncConfig | null>(globalConfig);
+  const [status, setStatus] = useState<WSLStatusResult | null>(globalStatus);
+  const [loading, setLoading] = useState(globalLoading);
+  const [syncing, setSyncing] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(globalLoadError);
+  const [syncWarning, setSyncWarning] = useState<string | null>(globalSyncWarning);
+  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(globalSyncProgress);
+
+  // Subscribe to global config/status changes
+  useEffect(() => {
+    configListeners.add(setConfig);
+    statusListeners.add(setStatus);
+    loadingListeners.add(setLoading);
+    loadErrorListeners.add(setLoadError);
+    syncWarningListeners.add(setSyncWarning);
+    syncProgressListeners.add(setSyncProgress);
+    // Sync with current global state
+    setConfig(globalConfig);
+    setStatus(globalStatus);
+    setLoading(globalLoading);
+    setLoadError(globalLoadError);
+    setSyncWarning(globalSyncWarning);
+    setSyncProgress(globalSyncProgress);
+    return () => {
+      configListeners.delete(setConfig);
+      statusListeners.delete(setStatus);
+      loadingListeners.delete(setLoading);
+      loadErrorListeners.delete(setLoadError);
+      syncWarningListeners.delete(setSyncWarning);
+      syncProgressListeners.delete(setSyncProgress);
+    };
+  }, []);
+
+  /**
+   * Load WSL sync configuration
+   */
+  const loadConfig = useCallback(async () => {
+    await loadConfigShared();
   }, []);
 
   /**
    * Load WSL sync status
    */
   const loadStatus = useCallback(async () => {
-    try {
-      setLoadError(null);
-      const data = await wslGetStatus();
-      setStatus(data);
-    } catch (error) {
-      console.error('Failed to load WSL status:', error);
-      setLoadError(error instanceof Error ? error.message : String(error));
-    }
+    await loadStatusShared();
   }, []);
 
   /**
@@ -104,17 +257,17 @@ export function useWSLSync() {
    */
   const saveConfig = useCallback(async (newConfig: WSLSyncConfig) => {
     try {
-      setLoading(true);
+      setGlobalLoading(true);
       await wslSaveConfig(newConfig);
-      setConfig(newConfig);
-      await loadStatus();
+      setGlobalConfig(newConfig);
+      await Promise.all([loadConfigShared(true), loadStatusShared(true)]);
     } catch (error) {
       console.error('Failed to save WSL config:', error);
       throw error;
     } finally {
-      setLoading(false);
+      setGlobalLoading(false);
     }
-  }, [loadStatus]);
+  }, []);
 
   /**
    * Execute sync operation
@@ -122,7 +275,7 @@ export function useWSLSync() {
   const sync = useCallback(async (module?: string) => {
     try {
       setSyncing(true);
-      setSyncProgress(null); // Clear previous progress
+      setGlobalSyncProgress(null); // Clear previous progress
       // Compute skip modules from visibleTabs
       const { visibleTabs } = useSettingsStore.getState();
       const visibleModules = visibleTabs
@@ -135,16 +288,16 @@ export function useWSLSync() {
         (m) => !visibleModules.includes(m) || wslDirectModules.includes(m)
       );
       const result = await wslSync(module, skipModules.length > 0 ? skipModules : undefined);
-      await loadStatus();
+      await loadStatusShared(true);
       return result;
     } catch (error) {
       console.error('Failed to sync:', error);
       throw error;
     } finally {
       setSyncing(false);
-      setSyncProgress(null); // Clear progress when done
+      setGlobalSyncProgress(null); // Clear progress when done
     }
-  }, [config?.moduleStatuses, loadStatus]);
+  }, [config?.moduleStatuses]);
 
   /**
    * Detect WSL availability
@@ -187,66 +340,43 @@ export function useWSLSync() {
    */
   const initializeDefaultConfig = useCallback(async () => {
     try {
-      setLoading(true);
+      setGlobalLoading(true);
       const defaultMappings = await getDefaultMappings();
-        const defaultConfig: WSLSyncConfig = {
-          enabled: false,
-          distro: 'Ubuntu',
-          syncMcp: true,
-          syncSkills: true,
-          fileMappings: defaultMappings,
-          moduleStatuses: [],
-          lastSyncStatus: 'never',
-        };
+      const defaultConfig: WSLSyncConfig = {
+        enabled: false,
+        distro: 'Ubuntu',
+        syncMcp: true,
+        syncSkills: true,
+        fileMappings: defaultMappings,
+        moduleStatuses: [],
+        lastSyncStatus: 'never',
+      };
       await wslSaveConfig(defaultConfig);
-      setConfig(defaultConfig);
+      setGlobalConfig(defaultConfig);
     } catch (error) {
       console.error('Failed to initialize default config:', error);
       throw error;
     } finally {
-      setLoading(false);
+      setGlobalLoading(false);
     }
   }, [getDefaultMappings]);
 
-  // Load config and status on mount
+  // Load config and status on mount (only for first instance)
   useEffect(() => {
-    loadConfig();
-    loadStatus();
-  }, [loadConfig, loadStatus]);
-
-  // Listen to WSL config changes
-  useEffect(() => {
-    const unlistenConfig = listen('wsl-config-changed', () => {
+    setupWslEventListeners();
+    if (globalConfig === null) {
       loadConfig();
+    }
+    if (globalStatus === null) {
       loadStatus();
-    });
-
-    const unlistenSync = listen<SyncResult>('wsl-sync-completed', () => {
-      loadStatus();
-      setSyncProgress(null); // Clear progress when sync completes
-    });
-
-    const unlistenWarning = listen<string>('wsl-sync-warning', (event) => {
-      setSyncWarning(event.payload);
-    });
-
-    const unlistenProgress = listen<SyncProgress>('wsl-sync-progress', (event) => {
-      setSyncProgress(event.payload);
-    });
-
-    return () => {
-      unlistenConfig.then(fn => fn());
-      unlistenSync.then(fn => fn());
-      unlistenWarning.then(fn => fn());
-      unlistenProgress.then(fn => fn());
-    };
+    }
   }, [loadConfig, loadStatus]);
 
   /**
    * Dismiss sync warning
    */
   const dismissSyncWarning = useCallback(() => {
-    setSyncWarning(null);
+    setGlobalSyncWarning(null);
   }, []);
 
   return {


### PR DESCRIPTION
## 背景
修复一个 WSL 同步的状态显示问题：UI 会短暂显示连接成功，但 1~2 秒后又切回“连接中/不可用”状态；与此同时，用户在间隙点击“立即同步”时，同步功能实际可以正常运行。

<img width="1596" height="1203" alt="2026-06-11-08-56-25" src="https://github.com/user-attachments/assets/2e5f2faf-b7a3-402f-bc0e-db18e473f941" />

## 变更内容
- 将 `useWSLSync` 的配置和状态提升为模块级共享状态，避免多个 hook 实例各自维护一份状态。
- WSL 相关事件监听只注册一次，避免 `MainLayout` 和 WSL 设置弹窗重复监听、重复触发刷新。
- 对配置/状态加载做请求去重，并忽略过期请求结果，避免旧响应覆盖新状态。
- WSL 发行版检查改为使用已有的 effective distro 解析逻辑，覆盖：
  - 发行版可用性检查
  - 发行版运行状态检查
  - 打开 WSL 终端
  - 打开 WSL 文件夹
- WSL 检测结果不再强行覆盖当前已选发行版，只在当前为空时使用检测到的第一个发行版。

## 原因
`useWSLSync` 同时被主布局顶部状态指示器和 WSL 设置弹窗使用。此前每个实例都会注册事件监听并触发配置/状态刷新，容易造成重叠请求和状态互相覆盖，从而出现连接状态反复闪烁。

另外，同步流程本身已经会通过 effective distro fallback 找到实际可用的 WSL 发行版，但部分 UI 状态检查仍然按配置值精确匹配。例如配置里是 `Ubuntu`，实际安装的是 `Ubuntu-22.04` 时，同步可以正常执行，但 UI 可能判断为不可用。

## 验证
- `pnpm exec tsc --noEmit`
- `cargo check`
- `git diff --check origin/main...HEAD`