### PR TITLE
fix(claude): add onClear handler to model selection input

### DIFF
--- a/web/features/coding/claudecode/components/ClaudeProviderFormModal.tsx
+++ b/web/features/coding/claudecode/components/ClaudeProviderFormModal.tsx
@@ -624,6 +624,7 @@ const ClaudeProviderFormModal: React.FC<ClaudeProviderFormModalProps> = ({
       style={{ width: '100%' }}
       filterOption={filterModelOption}
       onChange={onChange}
+      onClear={() => onChange('')}
     />
   ), [filterModelOption, modelOptions]);
 


### PR DESCRIPTION
## 问题
在新增/编辑 Claude Code 配置时，模型映射表单中“实际请求模型”右侧的清除按钮（×）点击后没有触发 `onChange`，导致：
- 实际请求模型字段未被清空
- 显示名称字段也未同步清空

## 修复
为 `AutoComplete` 组件显式添加 `onClear={() => onChange('')}`，使点击清除按钮时触发字段更新。`handleRoleModelChange` 在接收到空值后会同步将显示名称也置为空。

变更文件：`web/features/coding/claudecode/components/ClaudeProviderFormModal.tsx`

## 测试
- ✅ 启动本地 Tauri 桌面应用
- ✅ 进入新增/编辑 Claude Code 配置 → 模型映射
- ✅ 在实际请求模型输入框填入内容
- ✅ 点击右侧 × 按钮
- ✅ 验证：实际请求模型和显示名称同时被清空

## 本地验证

- ✅ 安装依赖：`pnpm install`
- ✅ 启动开发 Web 服务器：`pnpm tauri dev`
- ✅ 启动桌面应用：`cargo tauri dev`
- ✅ 代码检查：`pnpm tsc --noEmit`、`cd tauri && cargo check`
- ✅ 构建生产版本：`pnpm tauri build`

## Issue
#214 