### PR TITLE
test(ui): contain TOML regex regression hangs in worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ This document provides essential information for AI coding agents working on thi
 | `web/features/coding/shared/` | coding 共享前端语义：根目录弹窗、全局 prompt、favorite provider、会话面板、连通性测试 |
 | `web/features/coding/skills/` | Skills 前端页面、中央仓库视角、分组展示与批量同步交互 |
 | `web/features/settings/` | WSL/SSH 设置页、同步入口、moduleStatuses 消费和 UI 边界 |
+| `web/components/common/` | 共享编辑器与基础交互组件的性能和正确性约束 |
 | `tauri/src/settings/backup/` | 备份恢复、WebDAV、自动备份与恢复后续链路 |
 | `tauri/src/coding/image/` | Image 后端渠道配置、任务、资产落盘、图片 API 调用与备份联动 |
 

--- a/web/components/common/AGENTS.md
+++ b/web/components/common/AGENTS.md
@@ -1,0 +1,19 @@
+# Shared Components Development Guide
+
+## 一句话职责
+
+- 为多个页面提供编辑器和基础交互组件，并保证用户输入规模或内容形态不会阻塞前端主线程。
+
+## 核心设计决策（Why）
+
+- Monaco Monarch tokenizer 在 WebView 主线程执行。字符串规则必须保持线性时间；正则分支不能重叠消费同一字符，否则包含大量转义符的配置行会触发灾难性回溯并冻结整个主窗口。
+
+## 易错点与历史坑（Gotchas）
+
+- TOML 双引号字符串的“未闭合”规则中，转义分支 `\\.` 与普通字符分支必须互斥。普通字符分支必须排除反斜杠，使用 `[^"\\]`，不能退回会同时匹配反斜杠的 `[^\"]`。
+- 不要只用普通短配置验证 tokenizer。Codex `notify` 等配置会把 JSON 嵌入 TOML 字符串，形成包含大量反斜杠和转义引号的超长单行。
+
+## 最小验证
+
+- 修改 TOML tokenizer 后，运行 `web/test/components/common/TomlEditor/invalidDoubleQuoteStringPattern.test.ts`。
+- 性能回归测试必须在可终止的 Worker 中执行，避免危险正则重新出现时把完整测试进程永久卡住。

--- a/web/test/components/common/TomlEditor/invalidDoubleQuoteStringPattern.test.ts
+++ b/web/test/components/common/TomlEditor/invalidDoubleQuoteStringPattern.test.ts
@@ -2,11 +2,9 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { Worker } from 'node:worker_threads';
 
 import { INVALID_UNCLOSED_DOUBLE_QUOTE_STRING_PATTERN } from '../../../../components/common/TomlEditor/invalidDoubleQuoteStringPattern.ts';
-
-/** Legacy Monarch pattern that catastrophically backtracks on backslash-heavy closed strings. */
-const LEGACY_CATASTROPHIC_PATTERN = /"(\\.|[^"])*$/;
 
 /**
  * Monarch applies rules from the current cursor, so a match only counts when it
@@ -19,6 +17,40 @@ function matchesFromStart(pattern: RegExp, input: string): boolean {
   stickyPattern.lastIndex = 0;
   const match = stickyPattern.exec(input);
   return match !== null && match.index === 0;
+}
+
+function matchesFromStartInWorker(
+  pattern: RegExp,
+  input: string,
+  timeoutMs = 2_000,
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(`
+      const { parentPort, workerData } = require('node:worker_threads');
+      const flags = workerData.flags.replaceAll('g', '').replaceAll('y', '') + 'y';
+      const pattern = new RegExp(workerData.source, flags);
+      parentPort.postMessage(pattern.test(workerData.input));
+    `, {
+      eval: true,
+      workerData: { source: pattern.source, flags: pattern.flags, input },
+    });
+
+    const timeout = setTimeout(() => {
+      void worker.terminate();
+      reject(new Error(`TOML tokenizer pattern exceeded ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    worker.once('message', (matched: boolean) => {
+      clearTimeout(timeout);
+      void worker.terminate();
+      resolve(matched);
+    });
+    worker.once('error', (error) => {
+      clearTimeout(timeout);
+      void worker.terminate();
+      reject(error);
+    });
+  });
 }
 
 test('matches unclosed double-quoted strings from the start of the remaining input', () => {
@@ -40,42 +72,15 @@ test('does not match properly closed double-quoted strings from the start', () =
   );
 });
 
-test('stays linear on long closed notify-style lines with many backslashes', () => {
-  // ~40 path segments of doubled backslashes + closing quote.
-  // Legacy pattern takes multi-second (or freezes); fixed pattern must finish near-instantly.
-  const heavyPath = Array.from({ length: 40 }, (_, index) => `dir${index}`).join('\\\\');
-  const closedHeavyLine = `"C:\\\\Users\\\\Administrator\\\\AppData\\\\Local\\\\${heavyPath}\\\\nebula-hook.exe"`;
+test('does not backtrack exponentially on an adversarial closed notify-style line', async () => {
+  // The legacy alternatives can each consume `\a`, producing exponential paths before failure.
+  const closedBackslashHeavy = `"${String.raw`\a`.repeat(128)}" ]`;
 
-  const start = process.hrtime.bigint();
-  const matched = matchesFromStart(INVALID_UNCLOSED_DOUBLE_QUOTE_STRING_PATTERN, closedHeavyLine);
-  const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
-
-  assert.equal(matched, false);
-  assert.ok(
-    elapsedMs < 50,
-    `fixed pattern should finish well under 50ms on backslash-heavy closed strings, took ${elapsedMs.toFixed(2)}ms`,
-  );
-});
-
-test('legacy overlapping alternation is exponentially slower than the fixed pattern', () => {
-  // ~18 backslash pairs is enough to show the bug without multi-second CI hangs.
-  const closedBackslashHeavy = `"${'\\\\'.repeat(18)}x"`;
-
-  const legacyStart = process.hrtime.bigint();
-  matchesFromStart(LEGACY_CATASTROPHIC_PATTERN, closedBackslashHeavy);
-  const legacyMs = Number(process.hrtime.bigint() - legacyStart) / 1e6;
-
-  const fixedStart = process.hrtime.bigint();
-  matchesFromStart(INVALID_UNCLOSED_DOUBLE_QUOTE_STRING_PATTERN, closedBackslashHeavy);
-  const fixedMs = Number(process.hrtime.bigint() - fixedStart) / 1e6;
-
-  assert.ok(
-    fixedMs < 5,
-    `fixed pattern must stay near 0ms, took ${fixedMs.toFixed(2)}ms`,
-  );
-  // Guard against reintroducing /"(\\.|[^"])*$/ — on this input it is already much slower.
-  assert.ok(
-    legacyMs > 20 && legacyMs > fixedMs * 20,
-    `expected legacy pattern to be much slower than fixed (legacy=${legacyMs.toFixed(2)}ms, fixed=${fixedMs.toFixed(2)}ms)`,
+  assert.equal(
+    await matchesFromStartInWorker(
+      INVALID_UNCLOSED_DOUBLE_QUOTE_STRING_PATTERN,
+      closedBackslashHeavy,
+    ),
+    false,
   );
 });


### PR DESCRIPTION
## Context

The original UI freeze was reproducible when Codex `config.toml` contained a long, backslash-heavy `notify` line. Monaco tokenization runs on the WebView main thread, so catastrophic regex backtracking made the main window unresponsive while the native tray remained alive.

The core regex correction has already landed on `main` in 0df12bf. This PR hardens that regression coverage and records the invariant for future shared-editor changes.

## Problem

The previous regression test still depended on wall-clock thresholds and directly exercised regex work on the main test thread. Those thresholds vary across CI hosts, and a reintroduced pathological pattern could hang the entire test process instead of producing a bounded failure.

The shared-component guidance also did not document why the tokenizer alternatives must remain mutually exclusive.

## Approach

- Run the actual exported TOML tokenizer pattern against an adversarial closed `notify`-style string inside a disposable `node:worker_threads` Worker.
- Apply a 2-second deadline and terminate the Worker on timeout or error, so a ReDoS regression fails without blocking the full suite.
- Keep semantic assertions for start-anchored unclosed and properly closed strings.
- Document the root cause: in the legacy `/(\\.|[^"])*$/` shape, both alternatives can consume a backslash; the safe ordinary-character branch must exclude backslashes (`[^"\\]`).
- Add minimum validation guidance under `web/components/common/AGENTS.md` and link it from the root module index.

## Validation

- Targeted TomlEditor regression tests: 3/3 passed
- Full frontend tests: 253/253 passed
- TypeScript: `tsc --noEmit` passed
- `git diff --check` passed