### PR TITLE
fix(backup): restore applied OMO/OMOS runtime configs

### DIFF
--- a/tauri/src/coding/reapply_applied_runtime.rs
+++ b/tauri/src/coding/reapply_applied_runtime.rs
@@ -34,6 +34,25 @@ pub struct ReapplySummary {
     pub changed_modules: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreReapplyMode {
+    None,
+    Full,
+    PluginsOnly,
+}
+
+/// Select one mutually exclusive restore re-apply path. A full re-apply already includes the
+/// OpenCode companion plugins, so it always takes precedence over the resync-only path.
+pub fn restore_reapply_mode(need_full_reapply: bool, need_resync: bool) -> RestoreReapplyMode {
+    if need_full_reapply {
+        RestoreReapplyMode::Full
+    } else if need_resync {
+        RestoreReapplyMode::PluginsOnly
+    } else {
+        RestoreReapplyMode::None
+    }
+}
+
 #[derive(Debug, Default)]
 struct ReapplyCliResult {
     applied: Vec<String>,
@@ -80,6 +99,31 @@ pub async fn reapply_applied_runtime_after_restore<R: Runtime>(
     let pi_app = app.clone();
     reapply_cli(&mut summary, "pi", async move { reapply_pi(&pi_app).await }).await;
 
+    let plugin_summary = reapply_applied_opencode_plugins_after_restore(app).await;
+    summary.applied.extend(plugin_summary.applied);
+    summary.warnings.extend(plugin_summary.warnings);
+    for module in plugin_summary.changed_modules {
+        push_unique(&mut summary.changed_modules, &module);
+    }
+
+    // OpenCode main config, OpenClaw config, and Pi provider/model state are runtime-file-owned.
+    // They are intentionally preserved locally instead of being reconstructed from SQLite.
+    info!(
+        "Post-restore re-apply finished: applied={}, warnings={}",
+        summary.applied.len(),
+        summary.warnings.len()
+    );
+    summary
+}
+
+/// Re-apply only the DB-applied OpenCode companion plugin configurations restored by SQLite.
+/// This is used by ordinary restore resyncs where complete CLI runtime re-application is neither
+/// needed nor allowed.
+pub async fn reapply_applied_opencode_plugins_after_restore<R: Runtime>(
+    app: &AppHandle<R>,
+) -> ReapplySummary {
+    let mut summary = ReapplySummary::default();
+
     let openagent_app = app.clone();
     reapply_cli(&mut summary, "oh-my-openagent", async move {
         reapply_oh_my_openagent(&openagent_app).await
@@ -92,15 +136,7 @@ pub async fn reapply_applied_runtime_after_restore<R: Runtime>(
     })
     .await;
 
-    // OpenCode main config, OpenClaw config, and Pi provider/model state are runtime-file-owned.
-    // They are intentionally preserved locally instead of being reconstructed from SQLite.
     let _ = app.emit("config-changed", "restore-reapply");
-
-    info!(
-        "Post-restore re-apply finished: applied={}, warnings={}",
-        summary.applied.len(),
-        summary.warnings.len()
-    );
     summary
 }
 
@@ -732,8 +768,8 @@ pub fn reapply_flag_path(app_data_dir: &std::path::Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_record, resolve_record_id, unchanged_wsl_modules, wsl_module_for_reapply_label,
-        ReapplyCliResult,
+        apply_record, resolve_record_id, restore_reapply_mode, unchanged_wsl_modules,
+        wsl_module_for_reapply_label, ReapplyCliResult, RestoreReapplyMode,
     };
 
     #[tokio::test]
@@ -793,5 +829,19 @@ mod tests {
         assert!(skipped_modules.contains(&"openclaw".to_string()));
         assert!(skipped_modules.contains(&"geminicli".to_string()));
         assert!(skipped_modules.contains(&"pi".to_string()));
+    }
+
+    #[test]
+    fn full_restore_reapply_takes_precedence_over_plugin_only_reapply() {
+        assert_eq!(restore_reapply_mode(true, true), RestoreReapplyMode::Full);
+    }
+
+    #[test]
+    fn resync_without_full_flag_selects_plugin_only_reapply() {
+        assert_eq!(
+            restore_reapply_mode(false, true),
+            RestoreReapplyMode::PluginsOnly
+        );
+        assert_eq!(restore_reapply_mode(false, false), RestoreReapplyMode::None);
     }
 }

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -1674,12 +1674,31 @@ pub fn run() {
                     // Re-apply applied providers/prompts before skills/MCP so MCP can write into
                     // the freshly aligned CLI configs.
                     let mut changed_wsl_modules = restored_wsl_modules;
-                    if need_reapply {
-                        let summary =
-                            coding::reapply_applied_runtime::reapply_applied_runtime_after_restore(
-                                &app_clone,
-                            )
-                            .await;
+                    let reapply_mode =
+                        coding::reapply_applied_runtime::restore_reapply_mode(
+                            need_reapply,
+                            need_resync,
+                        );
+                    if reapply_mode
+                        != coding::reapply_applied_runtime::RestoreReapplyMode::None
+                    {
+                        let summary = match reapply_mode {
+                            coding::reapply_applied_runtime::RestoreReapplyMode::Full => {
+                                coding::reapply_applied_runtime::reapply_applied_runtime_after_restore(
+                                    &app_clone,
+                                )
+                                .await
+                            }
+                            coding::reapply_applied_runtime::RestoreReapplyMode::PluginsOnly => {
+                                coding::reapply_applied_runtime::reapply_applied_opencode_plugins_after_restore(
+                                    &app_clone,
+                                )
+                                .await
+                            }
+                            coding::reapply_applied_runtime::RestoreReapplyMode::None => {
+                                unreachable!("no re-apply mode was filtered above")
+                            }
+                        };
                         for module in &summary.changed_modules {
                             if !changed_wsl_modules
                                 .iter()
@@ -1689,7 +1708,8 @@ pub fn run() {
                             }
                         }
                         info!(
-                            "Post-restore re-apply completed: applied={}, warnings={}, changed_wsl_modules={:?}",
+                            "Post-restore re-apply completed: mode={:?}, applied={}, warnings={}, changed_wsl_modules={:?}",
+                            reapply_mode,
                             summary.applied.len(),
                             summary.warnings.len(),
                             changed_wsl_modules

--- a/tauri/src/settings/backup/AGENTS.md
+++ b/tauri/src/settings/backup/AGENTS.md
@@ -51,6 +51,7 @@ sequenceDiagram
 - 关闭 `backup_cli_config_files_enabled` 只跳过 **optional** 四工具的 `external-configs/<tool>/` 磁盘文件，不会跳过 DB 中已有记录；UI 仍可能显示「已应用」。Codex、Claude、Grok、Gemini CLI 的 applied provider/prompt 会重建。OpenCode/OpenClaw/Pi 文件仍从 zip 恢复；re-apply 里 OpenCode 仍会补 applied prompt 与已存储的 Oh My 配置，Pi 补 applied prompt，OpenClaw 不 re-apply；provider/model/main config **不从数据库猜写**。
 - `skip_cli_custom_roots=true` 时，SQLite restore 后要清空 common 中的 `root_dir/config_path`，且所有工具都不得读取备份里的 `root-dir.txt`。开关关闭但未勾选该选项时：always 三工具仍可读各自 `root-dir.txt`；optional 四工具不读。
 - re-apply 中 provider、prompt 和 Oh My config 是独立步骤：单步失败只记录 warning 并继续；Gateway takeover 只跳过被接管工具的 provider 投影，不能连 prompt 一起跳过。
+- 恢复启动编排中 `.reapply_applied_required` 优先并执行已含 OMO/OMOS 的全量 re-apply；只有 `.resync_required` 时仅串行重建 OMO/OMOS，随后继续 Skills、MCP 和单次 WSL sync，不能借普通恢复重写其它 CLI。
 - 恢复专用 apply/MCP 入口不得发中间 `wsl-sync-request-*`、`mcp-changed` 等自动同步事件。最终 WSL 同步只传播本轮实际改写的 CLI 模块，同时同步 MCP/Skills 一次，不能顺手覆盖受保护的 OpenClaw/OpenCode/Pi 本机运行时文件。
 - 普通 `timeout(work())` 无法可靠抢占卡在同步文件 I/O 的 future。re-apply 要在独立 task 中运行，超时后 abort 并继续下一个 CLI；写入前再用 `spawn_blocking` 做短时无写入路径探测，降低不可达 UNC 路径拖死恢复链路的概率。
 - 新增外部配置文件进入备份时，要同时检查本地备份、WebDAV 备份和 restore 路径，不要只改一个入口。


### PR DESCRIPTION
佬好，项目非常好用！不过在双设备使用过程中发现了一点小问题，简单修了一下，希望有所帮助。

## 背景

从本地备份或 WebDAV 备份恢复后，SQLite 中 Oh My OpenAgent（OMO）和 Oh My OpenCode Slim（OMOS）的 `is_applied` 状态会被正确恢复，但对应的 OpenCode 运行时配置文件不一定会被重新生成。

这会导致页面显示配置已应用，但实际运行时仍未生效；用户需要手动切换一次配置才能重新写入文件。

## 修复

沿用现有恢复后 re-apply 编排进行最小修复：

- 完整 `.reapply_applied_required` 流程保持优先，并继续执行现有全量 re-apply。
- 只有 `.resync_required` 的普通恢复流程，仅重应用数据库中已应用的 OMO/OMOS 配置。
- 复用现有的无事件 apply 入口，不在恢复过程中触发额外的中间同步。
- 插件重应用完成后，继续沿用现有的 Skills、MCP 和单次 WSL sync 收尾流程。
- 完整 re-apply 已包含 OMO/OMOS，因此两个恢复标记同时存在时不会重复应用插件。

## 范围

本次修改仅补充恢复后 OMO/OMOS 运行时配置的重建逻辑，没有：

- 修改本地或 WebDAV 备份格式；
- 将 OMO/OMOS 配置文件加入备份包；
- 改变其他 CLI 的 re-apply 条件；
- 重写 OpenCode 主配置或其他受保护的运行时文件；
- 修改 UI 或 i18n。

## 验证

运行：

```bash
cargo test coding::reapply_applied_runtime::tests --lib
```

结果：

```text
6 passed; 0 failed
```

新增测试覆盖：

- 完整 re-apply 标记优先于 plugin-only re-apply；
- 只有 resync 标记时选择 OMO/OMOS plugin-only re-apply；
- 保持现有 WSL 未修改模块跳过语义。

同时通过：

```bash
git diff --check
rustfmt --edition 2021 --check src/coding/reapply_applied_runtime.rs
rustfmt --edition 2021 --check --config skip_children=true src/lib.rs
```

并进行了手动编译验证，可以正常在同步后直接应用变更了。