### PR TITLE
feat(pi): 支持 Oh My Pi 配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ This document provides essential information for AI coding agents working on thi
 | `tauri/src/coding/open_claw/` | OpenClaw 后端配置文件与 WSL 同步约束 |
 | `tauri/src/coding/oh_my_openagent/` | Oh My OpenAgent 后端配置、临时本地态、应用链路与 OpenCode WSL 联动 |
 | `tauri/src/coding/oh_my_opencode_slim/` | Oh My OpenCode Slim 后端配置、临时本地态、应用链路与 OpenCode WSL 联动 |
+| `tauri/src/coding/oh_my_pi/` | Oh My Pi 运行时根目录、models.yml provider 与原生 MCP 路径边界 |
 | `tauri/src/coding/proxy_gateway/` | 本机代理网关、CLI 接管 manifest、配置备份恢复与模型级健康/日志文件 |
 | `tauri/src/coding/proxy_gateway/transformer/` | 网关协议转换独立模块：Anthropic/OpenAI Chat/OpenAI Responses/Gemini Native JSON 与 SSE 互转 |
 | `tauri/src/coding/session_manager/` | 会话浏览、详情、重命名、导入导出与运行时路径解析 |

--- a/tauri/src/coding/mcp/AGENTS.md
+++ b/tauri/src/coding/mcp/AGENTS.md
@@ -46,6 +46,7 @@ sequenceDiagram
 - Grok 是明确例外：官方 Grok MCP schema 在 Windows 本机、WSL 和 SSH 都保持裸 `npx`，不写 `cmd /c`；同时使用 `headers` 而非 Codex 的 `http_headers`，不写 `type`，并保留 `cwd/enabled/startup_timeout_sec/tool_timeout_sec/tool_timeouts/bearer_token_env_var`。
 - Codex 与 Grok 共享秒级超时字段 `startup_timeout_sec` / `tool_timeout_sec`，存放在中心存储的 `server_config` 里（不是顶层 OpenCode 毫秒字段 `timeout`）。同步到 Codex `config.toml` 时由 `build_toml_edit_server_config` 写出；未设置则不写，让 Codex 使用官方默认（启动约 10s、工具约 60s）。导入 Codex TOML 时必须回读这两个字段，避免再同步时丢失。
 - Pi 的 MCP 目标不是 Pi 原生能力，而是 `pi-mcp-adapter` 扩展读取的 `<Pi runtime root>/mcp.json`。同步时仍以中心 MCP 存储为 source of truth，只把标准 JSON `mcpServers` 写入该派生配置文件。
+- Oh My Pi 原生读取 `<OMP runtime root>/mcp.json`，根字段为 `mcpServers`。同步目标路径必须消费 OMP 独立 custom root，不能退回 Pi root 或固定 `~/.omp/agent`；AI Toolbox 首次创建文件时写入官方 `$schema` URL，并保留已有的 `disabledServers` / `enabledServers` 等顶层字段。
 - Antigravity 2.0 的远程 HTTP MCP 字段是 `serverUrl`，不是 Gemini/Qwen 的 `httpUrl`，也不是通用 `url`。中心存储仍统一用 `server_config.url`，只在同步到 Antigravity 配置和从 Antigravity 配置扫描时做字段转换；扫描时要兼容历史写出的 `httpUrl`，避免丢用户已有配置。
 - 「导入现有 MCP」扫描除已安装工具配置与 Claude 插件 `.mcp.json` 外，还会只读扫描 CC Switch `~/.cc-switch/cc-switch.db` 的 `mcp_servers` 表。发现结果使用合成 `tool_key = "cc_switch"` / 显示名 `CC Switch`（前端走 pluginGroups 同款分组，无独立按钮）。`mcp_import_from_tool("cc_switch")` 必须单独分支再读该表并 upsert；不要把 CCS 当 runtime tool，也不要写回 CCS。同步目标仍是弹窗勾选的 `enabledTools`，不用 CCS 的 `enabled_*` 列。
 

--- a/tauri/src/coding/mcp/config_sync.rs
+++ b/tauri/src/coding/mcp/config_sync.rs
@@ -19,6 +19,8 @@ use crate::coding::{
     },
 };
 
+const OMP_MCP_SCHEMA_URL: &str = "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json";
+
 /// Sync an MCP server to a specific tool's config file
 pub fn sync_server_to_tool(
     db: &crate::db::SqliteDbState,
@@ -175,6 +177,8 @@ fn sync_server_to_json(
         serde_json::json!({})
     };
 
+    ensure_omp_mcp_schema(&mut config, tool_key)?;
+
     // Ensure parent directory exists
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
@@ -202,6 +206,18 @@ fn sync_server_to_json(
     std::fs::write(config_path, content)
         .map_err(|e| format!("Failed to write config file: {}", e))?;
 
+    Ok(())
+}
+
+fn ensure_omp_mcp_schema(config: &mut Value, tool_key: &str) -> Result<(), String> {
+    if tool_key != "oh_my_pi" {
+        return Ok(());
+    }
+    config
+        .as_object_mut()
+        .ok_or_else(|| "OMP MCP config root must be a JSON object".to_string())?
+        .entry("$schema".to_string())
+        .or_insert_with(|| Value::String(OMP_MCP_SCHEMA_URL.to_string()));
     Ok(())
 }
 
@@ -1394,6 +1410,19 @@ mod tests {
     use super::*;
     use crate::coding::mcp::format_configs::get_format_config;
     use serde_json::json;
+
+    #[test]
+    fn omp_schema_is_added_without_overwriting_top_level_fields() {
+        let mut config = json!({
+            "disabledServers": ["legacy"],
+            "mcpServers": {}
+        });
+
+        ensure_omp_mcp_schema(&mut config, "oh_my_pi").expect("add schema");
+
+        assert_eq!(config["$schema"], OMP_MCP_SCHEMA_URL);
+        assert_eq!(config["disabledServers"], json!(["legacy"]));
+    }
 
     fn build_openclaw_stdio_server() -> McpServer {
         McpServer {

--- a/tauri/src/coding/mod.rs
+++ b/tauri/src/coding/mod.rs
@@ -13,6 +13,7 @@ pub mod magic_context;
 pub mod mcp;
 pub mod oh_my_openagent;
 pub mod oh_my_opencode_slim;
+pub mod oh_my_pi;
 pub mod open_claw;
 pub mod open_code;
 pub mod pi;

--- a/tauri/src/coding/oh_my_pi/AGENTS.md
+++ b/tauri/src/coding/oh_my_pi/AGENTS.md
@@ -1,0 +1,22 @@
+# Oh My Pi 后端模块说明
+
+## 一句话职责
+
+- `oh_my_pi/` 只负责 OMP 运行时根目录和 `models.yml` provider 配置；`config.yml` 与认证数据库继续由 OMP 自己管理。
+
+## Source of Truth
+
+- OMP provider 的事实源是当前运行时根目录的 `models.yml`。
+- OMP MCP server 主数据仍属于全局 MCP 模块，派生文件是当前运行时根目录的 `mcp.json`。
+- 自定义根目录复用 `pi_settings_config` 表的独立 `oh_my_pi` 记录，与 Pi 的 `common` 记录隔离。
+
+## Gotchas
+
+- OMP 与 Pi 都识别 `PI_CODING_AGENT_DIR`，但应用内自定义根目录必须分别保存，不能切换 OMP 时覆盖 Pi root。
+- `models.yml` 允许 override-only provider 和未知字段。按 provider key 写入时必须保留其他 provider 及未知字段。
+- 不要接管 `config.yml`；默认模型、角色和 OMP 其他设置由 OMP TUI/CLI 维护。
+
+## 最小验证
+
+- 新增、修改、删除一个 provider 后，其他 provider 和未知字段保持不变。
+- custom root 指向 WSL UNC 目录时，`models.yml` 与 MCP `mcp.json` 都从该目录派生。

--- a/tauri/src/coding/oh_my_pi/commands.rs
+++ b/tauri/src/coding/oh_my_pi/commands.rs
@@ -1,0 +1,301 @@
+use chrono::Local;
+use serde_json::{json, Map, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::Emitter;
+
+use super::types::*;
+use crate::coding::open_code::shell_env;
+use crate::db::helpers::{db_get, db_put};
+use crate::db::schema::DbTable;
+use crate::db::SqliteDbState;
+
+const OMP_SETTINGS_RECORD_ID: &str = "oh_my_pi";
+const OMP_ENV_KEY: &str = "PI_CODING_AGENT_DIR";
+const OMP_MODELS_FILE: &str = "models.yml";
+const OMP_MCP_FILE: &str = "mcp.json";
+
+fn home_dir() -> Result<PathBuf, String> {
+    std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .map(PathBuf::from)
+        .map_err(|_| "Failed to get home directory".to_string())
+}
+
+pub fn get_omp_default_root_dir() -> Result<PathBuf, String> {
+    Ok(home_dir()?.join(".omp").join("agent"))
+}
+
+fn settings_from_value(value: Value) -> OmpSettingsConfig {
+    OmpSettingsConfig {
+        root_dir: value
+            .get("root_dir")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        updated_at: value
+            .get("updated_at")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| Local::now().to_rfc3339()),
+    }
+}
+
+fn custom_root(db: &SqliteDbState) -> Result<Option<PathBuf>, String> {
+    Ok(db
+        .with_conn(|conn| db_get(conn, DbTable::PiSettingsConfig, OMP_SETTINGS_RECORD_ID))?
+        .map(settings_from_value)
+        .and_then(|settings| settings.root_dir)
+        .filter(|path| !path.trim().is_empty())
+        .map(PathBuf::from))
+}
+
+pub fn get_omp_root_path_info_from_db(db: &SqliteDbState) -> Result<OmpPathInfo, String> {
+    if let Some(path) = custom_root(db)? {
+        return Ok(OmpPathInfo {
+            path: path.to_string_lossy().to_string(),
+            source: "custom".to_string(),
+        });
+    }
+    if let Ok(path) = std::env::var(OMP_ENV_KEY) {
+        if !path.trim().is_empty() {
+            return Ok(OmpPathInfo {
+                path,
+                source: "env".to_string(),
+            });
+        }
+    }
+    if let Some(path) =
+        shell_env::get_env_from_shell_config(OMP_ENV_KEY).filter(|path| !path.trim().is_empty())
+    {
+        return Ok(OmpPathInfo {
+            path,
+            source: "shell".to_string(),
+        });
+    }
+    Ok(OmpPathInfo {
+        path: get_omp_default_root_dir()?.to_string_lossy().to_string(),
+        source: "default".to_string(),
+    })
+}
+
+pub fn get_omp_mcp_path_from_db(db: &SqliteDbState) -> Result<PathBuf, String> {
+    Ok(PathBuf::from(get_omp_root_path_info_from_db(db)?.path).join(OMP_MCP_FILE))
+}
+
+fn read_models(path: &Path) -> Result<Value, String> {
+    if !path.exists() {
+        return Ok(json!({ "providers": {} }));
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("Failed to read OMP models.yml: {error}"))?;
+    if content.trim().is_empty() {
+        return Ok(json!({ "providers": {} }));
+    }
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&content)
+        .map_err(|error| format!("Failed to parse OMP models.yml: {error}"))?;
+    let value = serde_json::to_value(yaml)
+        .map_err(|error| format!("Failed to convert OMP models.yml: {error}"))?;
+    if !value.is_object() {
+        return Err("OMP models.yml root must be an object".to_string());
+    }
+    Ok(value)
+}
+
+fn write_models(path: &Path, value: &Value) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create OMP config directory: {error}"))?;
+    }
+    let yaml = serde_yaml::to_string(value)
+        .map_err(|error| format!("Failed to serialize OMP models.yml: {error}"))?;
+    fs::write(path, yaml).map_err(|error| format!("Failed to write OMP models.yml: {error}"))
+}
+
+fn ensure_providers(models: &mut Value) -> Result<&mut Map<String, Value>, String> {
+    let root = models
+        .as_object_mut()
+        .ok_or_else(|| "OMP models.yml root must be an object".to_string())?;
+    if !root.get("providers").is_some_and(Value::is_object) {
+        root.insert("providers".to_string(), Value::Object(Map::new()));
+    }
+    root.get_mut("providers")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| "OMP models.yml providers must be an object".to_string())
+}
+
+async fn read_runtime(db: &SqliteDbState) -> Result<OmpRuntimeConfig, String> {
+    let root_path_info = get_omp_root_path_info_from_db(db)?;
+    let root = PathBuf::from(&root_path_info.path);
+    let models_path = root.join(OMP_MODELS_FILE);
+    let models = read_models(&models_path)?;
+    let providers = models
+        .get("providers")
+        .cloned()
+        .filter(Value::is_object)
+        .unwrap_or_else(|| Value::Object(Map::new()));
+    Ok(OmpRuntimeConfig {
+        root_path_info,
+        models_path: models_path.to_string_lossy().to_string(),
+        mcp_path: root.join(OMP_MCP_FILE).to_string_lossy().to_string(),
+        models,
+        providers,
+    })
+}
+
+#[tauri::command]
+pub async fn get_omp_settings_config(
+    state: tauri::State<'_, SqliteDbState>,
+) -> Result<Option<OmpSettingsConfig>, String> {
+    Ok(state
+        .db()
+        .with_conn(|conn| db_get(conn, DbTable::PiSettingsConfig, OMP_SETTINGS_RECORD_ID))?
+        .map(settings_from_value))
+}
+
+#[tauri::command]
+pub async fn save_omp_settings_config(
+    state: tauri::State<'_, SqliteDbState>,
+    app: tauri::AppHandle,
+    input: OmpSettingsConfigInput,
+) -> Result<(), String> {
+    let existing = get_omp_settings_config(state.clone()).await?;
+    let root_dir = if input.clear_root_dir {
+        None
+    } else {
+        input
+            .root_dir
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(str::to_string)
+            .or_else(|| existing.and_then(|settings| settings.root_dir))
+    };
+    let mut value = json!({ "updated_at": Local::now().to_rfc3339() });
+    if let Some(root_dir) = root_dir {
+        value["root_dir"] = json!(root_dir);
+    }
+    state.db().with_conn(|conn| {
+        db_put(
+            conn,
+            DbTable::PiSettingsConfig,
+            OMP_SETTINGS_RECORD_ID,
+            &value,
+        )
+    })?;
+    let _ = app.emit("config-changed", "window");
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn read_omp_runtime_config(
+    state: tauri::State<'_, SqliteDbState>,
+) -> Result<OmpRuntimeConfig, String> {
+    read_runtime(state.db()).await
+}
+
+#[tauri::command]
+pub async fn save_omp_provider(
+    state: tauri::State<'_, SqliteDbState>,
+    app: tauri::AppHandle,
+    input: OmpProviderInput,
+) -> Result<OmpRuntimeConfig, String> {
+    let provider_key = input.provider_key.trim();
+    if provider_key.is_empty() {
+        return Err("OMP provider key is required".to_string());
+    }
+    if !input.provider.is_object() {
+        return Err("OMP provider config must be an object".to_string());
+    }
+    let path =
+        PathBuf::from(get_omp_root_path_info_from_db(state.db())?.path).join(OMP_MODELS_FILE);
+    let mut models = read_models(&path)?;
+    ensure_providers(&mut models)?.insert(provider_key.to_string(), input.provider);
+    write_models(&path, &models)?;
+    let _ = app.emit("config-changed", "window");
+    read_runtime(state.db()).await
+}
+
+#[tauri::command]
+pub async fn delete_omp_provider(
+    state: tauri::State<'_, SqliteDbState>,
+    app: tauri::AppHandle,
+    provider_key: String,
+) -> Result<OmpRuntimeConfig, String> {
+    let provider_key = provider_key.trim();
+    if provider_key.is_empty() {
+        return Err("OMP provider key is required".to_string());
+    }
+    let path =
+        PathBuf::from(get_omp_root_path_info_from_db(state.db())?.path).join(OMP_MODELS_FILE);
+    let mut models = read_models(&path)?;
+    ensure_providers(&mut models)?.remove(provider_key);
+    write_models(&path, &models)?;
+    let _ = app.emit("config-changed", "window");
+    read_runtime(state.db()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_round_trip_preserves_unknown_provider_fields() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join(OMP_MODELS_FILE);
+        let value = json!({
+            "providers": {
+                "gateway": {
+                    "baseUrl": "https://example.com/v1",
+                    "api": "openai-responses",
+                    "customField": { "enabled": true },
+                    "models": [{ "id": "gpt-test", "unknown": 42 }]
+                }
+            }
+        });
+        write_models(&path, &value).expect("write models");
+        assert_eq!(read_models(&path).expect("read models"), value);
+    }
+
+    #[test]
+    fn provider_upsert_preserves_siblings_and_unknown_root_fields() {
+        let mut models = json!({
+            "providers": {
+                "first": { "api": "openai-responses" },
+                "second": { "api": "anthropic-messages" }
+            },
+            "futureRootField": true
+        });
+
+        ensure_providers(&mut models)
+            .expect("providers")
+            .insert("first".to_string(), json!({ "api": "openai-completions" }));
+
+        assert_eq!(models["providers"]["second"]["api"], "anthropic-messages");
+        assert_eq!(models["futureRootField"], true);
+    }
+
+    #[tokio::test]
+    async fn mcp_path_resolvers_use_the_independent_custom_root() {
+        let db = SqliteDbState::in_memory_for_test().expect("test database");
+        let root = PathBuf::from(r"\\wsl.localhost\Ubuntu\home\tester\.omp\agent");
+        db.with_conn(|conn| {
+            db_put(
+                conn,
+                DbTable::PiSettingsConfig,
+                OMP_SETTINGS_RECORD_ID,
+                &json!({ "root_dir": root.to_string_lossy() }),
+            )
+        })
+        .expect("save OMP root");
+
+        let expected = root.join(OMP_MCP_FILE);
+        assert_eq!(
+            crate::coding::runtime_location::get_tool_mcp_config_path_sync(&db, "oh_my_pi"),
+            Some(expected.clone())
+        );
+        assert_eq!(
+            crate::coding::runtime_location::get_tool_mcp_config_path_async(&db, "oh_my_pi").await,
+            Some(expected)
+        );
+    }
+}

--- a/tauri/src/coding/oh_my_pi/mod.rs
+++ b/tauri/src/coding/oh_my_pi/mod.rs
@@ -1,0 +1,4 @@
+mod commands;
+mod types;
+
+pub use commands::*;

--- a/tauri/src/coding/oh_my_pi/types.rs
+++ b/tauri/src/coding/oh_my_pi/types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpPathInfo {
+    pub path: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpSettingsConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_dir: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpSettingsConfigInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_dir: Option<String>,
+    #[serde(default)]
+    pub clear_root_dir: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpRuntimeConfig {
+    pub root_path_info: OmpPathInfo,
+    pub models_path: String,
+    pub mcp_path: String,
+    pub models: Value,
+    pub providers: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OmpProviderInput {
+    pub provider_key: String,
+    pub provider: Value,
+}

--- a/tauri/src/coding/runtime_location.rs
+++ b/tauri/src/coding/runtime_location.rs
@@ -1496,6 +1496,7 @@ pub fn get_tool_mcp_config_path_sync(
         "pi" => get_pi_runtime_location_sync(db)
             .ok()
             .map(|location| get_pi_mcp_config_path_from_location(&location)),
+        "oh_my_pi" => crate::coding::oh_my_pi::get_omp_mcp_path_from_db(db).ok(),
         _ => None,
     }
 }
@@ -1520,6 +1521,7 @@ pub async fn get_tool_mcp_config_path_async(
             .await
             .ok()
             .map(|location| get_pi_mcp_config_path_from_location(&location)),
+        "oh_my_pi" => crate::coding::oh_my_pi::get_omp_mcp_path_from_db(db).ok(),
         _ => None,
     }
 }

--- a/tauri/src/coding/tools/AGENTS.md
+++ b/tauri/src/coding/tools/AGENTS.md
@@ -8,13 +8,13 @@
 
 - 内置工具定义来自 `builtin.rs` 的静态配置。
 - 用户自定义工具来自主数据库的 `custom_tool` 表；必须直接读写 SQLite JSONB，旧 SurrealDB 仅用于启动时一次性导入。这部分是 Skills/MCP 对“额外工具”的唯一持久化来源。
-- 对 OpenCode、Claude Code、Codex、Grok、OpenClaw、Pi 这类 runtime root 可配置的内置工具，真正的 MCP/Skills 路径不能只看静态字符串，必须优先经过 `runtime_location` 派生。
+- 对 OpenCode、Claude Code、Codex、Grok、OpenClaw、Pi、Oh My Pi 这类 runtime root 可配置的内置工具，真正的 MCP/Skills 路径不能只看静态字符串，必须优先经过动态根目录派生。
 
 ## 核心设计决策（Why）
 
 - Skills 和 MCP 共用同一套 `RuntimeTool` 抽象，避免两个功能各维护一套工具列表和检测规则。
 - 自定义工具字段分为 Skills 相关和 MCP 相关，保存时要保留另一侧字段，不能互相覆盖。
-- 对 OpenCode、Claude Code、Codex、OpenClaw、Pi 这些内置工具，带数据库上下文的路径解析必须优先于静态默认值，否则 WSL Direct 场景会错。
+- 对 OpenCode、Claude Code、Codex、OpenClaw、Pi、Oh My Pi 这些内置工具，带数据库上下文的路径解析必须优先于静态默认值，否则 WSL Direct 场景会错。
 
 ## 关键流程
 
@@ -35,7 +35,7 @@ sequenceDiagram
 
 - 不要把“自定义工具”当成一定已安装的真实运行时。当前检测层对 custom tool 默认视为可用，业务层要理解这是产品约束，不是系统级验证。
 - 保存自定义工具时，Skills 字段和 MCP 字段必须互相保留；只更新一侧时不要把另一侧清空。
-- OpenCode、Claude Code、Codex、OpenClaw、Pi 的 Skills/MCP 路径在 WSL Direct 场景下必须用 `*_with_db` 版本解析，不能退回静态默认路径。
+- OpenCode、Claude Code、Codex、OpenClaw、Pi、Oh My Pi 的 Skills/MCP 路径在 WSL Direct 场景下必须用 `*_with_db` 版本解析，不能退回静态默认路径。
 
 ## 跨模块依赖
 
@@ -52,4 +52,4 @@ sequenceDiagram
 ## 最小验证
 
 - 至少验证：内置工具与自定义工具都能正确出现在 Skills/MCP 工具列表中。
-- 至少验证：WSL Direct 场景下 OpenCode、Claude Code、Codex、OpenClaw、Pi 的 MCP/Skills 路径仍从 runtime_location 解析。
+- 至少验证：WSL Direct 场景下 OpenCode、Claude Code、Codex、OpenClaw、Pi、Oh My Pi 的 MCP/Skills 路径仍从动态运行时根目录解析。

--- a/tauri/src/coding/tools/builtin.rs
+++ b/tauri/src/coding/tools/builtin.rs
@@ -185,6 +185,16 @@ pub const BUILTIN_TOOLS: &[BuiltinTool] = &[
         mcp_config_format: Some("json"),
         mcp_field: Some("mcpServers"),
     },
+    // Oh My Pi - native MCP configuration. Skills are auto-discovered by OMP.
+    BuiltinTool {
+        key: "oh_my_pi",
+        display_name: "Oh My Pi",
+        relative_skills_dir: None,
+        relative_detect_dir: Some("~/.omp/agent"),
+        mcp_config_path: Some("~/.omp/agent/mcp.json"),
+        mcp_config_format: Some("json"),
+        mcp_field: Some("mcpServers"),
+    },
     // QoderWork - supports both Skills and MCP
     BuiltinTool {
         key: "qoder_work",

--- a/tauri/src/coding/tools/detection.rs
+++ b/tauri/src/coding/tools/detection.rs
@@ -110,7 +110,13 @@ pub fn resolve_mcp_config_path_with_db(
     tool: &RuntimeTool,
 ) -> Option<PathBuf> {
     match tool.key.as_str() {
-        "opencode" | "claude_code" | "codex" | "grok" | "openclaw" | "pi" => {
+        "opencode"
+        | "claude_code"
+        | "codex"
+        | "grok"
+        | "openclaw"
+        | "pi"
+        | "oh_my_pi" => {
             crate::coding::runtime_location::get_tool_mcp_config_path_sync(db, &tool.key)
                 .or_else(|| resolve_mcp_config_path(tool))
         }
@@ -123,7 +129,13 @@ pub async fn resolve_mcp_config_path_with_db_async(
     tool: &RuntimeTool,
 ) -> Option<PathBuf> {
     match tool.key.as_str() {
-        "opencode" | "claude_code" | "codex" | "grok" | "openclaw" | "pi" => {
+        "opencode"
+        | "claude_code"
+        | "codex"
+        | "grok"
+        | "openclaw"
+        | "pi"
+        | "oh_my_pi" => {
             crate::coding::runtime_location::get_tool_mcp_config_path_async(db, &tool.key)
                 .await
                 .or_else(|| resolve_mcp_config_path(tool))

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -2211,6 +2211,12 @@ pub fn run() {
             coding::pi::apply_pi_prompt_config,
             coding::pi::reorder_pi_prompt_configs,
             coding::pi::save_pi_local_prompt_config,
+            // Oh My Pi
+            coding::oh_my_pi::get_omp_settings_config,
+            coding::oh_my_pi::save_omp_settings_config,
+            coding::oh_my_pi::read_omp_runtime_config,
+            coding::oh_my_pi::save_omp_provider,
+            coding::oh_my_pi::delete_omp_provider,
             // OpenClaw
             coding::open_claw::get_openclaw_config_path,
             coding::open_claw::get_openclaw_config_path_info,

--- a/web/features/coding/pi/components/OhMyPiConfigModal.module.less
+++ b/web/features/coding/pi/components/OhMyPiConfigModal.module.less
@@ -1,0 +1,42 @@
+.rootSection {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+  margin-bottom: 16px;
+}
+
+.pathMeta {
+  margin-top: 6px;
+  font-size: 10px;
+  color: var(--color-text-tertiary);
+  overflow-wrap: anywhere;
+}
+
+.providerHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.providerList {
+  border-top: 1px solid var(--color-border);
+}
+
+.providerKey {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.providerMeta {
+  font-size: 10px;
+  color: var(--color-text-tertiary);
+}
+
+@media (max-width: 640px) {
+  .rootSection {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/features/coding/pi/components/OhMyPiConfigModal.tsx
+++ b/web/features/coding/pi/components/OhMyPiConfigModal.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { Button, Empty, Form, Input, List, Modal, Space, Spin, Typography, message } from 'antd';
+import { DeleteOutlined, EditOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+import JsonEditor from '@/components/common/JsonEditor';
+import {
+  deleteOmpProvider,
+  readOmpRuntimeConfig,
+  saveOmpProvider,
+  saveOmpSettingsConfig,
+} from '@/services/ohMyPiApi';
+import type { OmpRuntimeConfig } from '@/types/ohMyPi';
+
+import styles from './OhMyPiConfigModal.module.less';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface ProviderEditorState {
+  originalKey?: string;
+  providerKey: string;
+  provider: Record<string, unknown>;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+);
+
+const OhMyPiConfigModal: React.FC<Props> = ({ open, onClose }) => {
+  const { t } = useTranslation();
+  const [loading, setLoading] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+  const [runtime, setRuntime] = React.useState<OmpRuntimeConfig | null>(null);
+  const [rootDir, setRootDir] = React.useState('');
+  const [editor, setEditor] = React.useState<ProviderEditorState | null>(null);
+  const [providerValid, setProviderValid] = React.useState(true);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await readOmpRuntimeConfig();
+      setRuntime(next);
+      setRootDir(next.rootPathInfo.path);
+    } catch (error) {
+      console.error('Failed to load Oh My Pi config:', error);
+      message.error(t('ohMyPi.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  React.useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  const saveRoot = async () => {
+    setSaving(true);
+    try {
+      await saveOmpSettingsConfig({ rootDir: rootDir.trim() });
+      await load();
+      message.success(t('common.success'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const resetRoot = async () => {
+    setSaving(true);
+    try {
+      await saveOmpSettingsConfig({ clearRootDir: true });
+      await load();
+      message.success(t('common.success'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const submitProvider = async () => {
+    if (!editor || !editor.providerKey.trim() || !providerValid) return;
+    setSaving(true);
+    try {
+      let next = await saveOmpProvider({
+        providerKey: editor.providerKey.trim(),
+        provider: editor.provider,
+      });
+      if (editor.originalKey && editor.originalKey !== editor.providerKey.trim()) {
+        next = await deleteOmpProvider(editor.originalKey);
+      }
+      setRuntime(next);
+      setEditor(null);
+      message.success(t('common.success'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeProvider = (providerKey: string) => {
+    Modal.confirm({
+      title: t('ohMyPi.deleteTitle'),
+      content: providerKey,
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        setRuntime(await deleteOmpProvider(providerKey));
+      },
+    });
+  };
+
+  const providers = Object.entries(runtime?.providers ?? {});
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onCancel={onClose}
+        footer={null}
+        width={860}
+        title={t('ohMyPi.title')}
+        destroyOnHidden
+      >
+        <Spin spinning={loading || saving}>
+          <div className={styles.rootSection}>
+            <div>
+              <Typography.Text strong>{t('ohMyPi.rootDir')}</Typography.Text>
+              <Input value={rootDir} onChange={(event) => setRootDir(event.target.value)} />
+              <div className={styles.pathMeta}>
+                {runtime?.modelsPath}<br />{runtime?.mcpPath}
+              </div>
+            </div>
+            <Space>
+              <Button onClick={resetRoot}>{t('common.reset')}</Button>
+              <Button type="primary" onClick={saveRoot}>{t('common.save')}</Button>
+            </Space>
+          </div>
+
+          <div className={styles.providerHeader}>
+            <Typography.Text strong>{t('ohMyPi.providers')}</Typography.Text>
+            <Space>
+              <Button icon={<ReloadOutlined />} onClick={() => void load()}>
+                {t('common.refresh')}
+              </Button>
+              <Button
+                type="primary"
+                icon={<PlusOutlined />}
+                onClick={() => setEditor({ providerKey: '', provider: {} })}
+              >
+                {t('common.add')}
+              </Button>
+            </Space>
+          </div>
+
+          {providers.length === 0 ? <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} /> : (
+            <List
+              className={styles.providerList}
+              dataSource={providers}
+              renderItem={([providerKey, provider]) => (
+                <List.Item
+                  actions={[
+                    <Button
+                      key="edit"
+                      type="text"
+                      icon={<EditOutlined />}
+                      aria-label={t('common.edit')}
+                      onClick={() => setEditor({ originalKey: providerKey, providerKey, provider })}
+                    />,
+                    <Button
+                      key="delete"
+                      type="text"
+                      danger
+                      icon={<DeleteOutlined />}
+                      aria-label={t('common.delete')}
+                      onClick={() => removeProvider(providerKey)}
+                    />,
+                  ]}
+                >
+                  <List.Item.Meta
+                    title={<span className={styles.providerKey}>{providerKey}</span>}
+                    description={(
+                      <span className={styles.providerMeta}>
+                        {[provider.api, provider.baseUrl].filter(Boolean).join(' · ') || t('ohMyPi.overrideOnly')}
+                      </span>
+                    )}
+                  />
+                </List.Item>
+              )}
+            />
+          )}
+        </Spin>
+      </Modal>
+
+      <Modal
+        open={!!editor}
+        onCancel={() => setEditor(null)}
+        onOk={() => void submitProvider()}
+        confirmLoading={saving}
+        okButtonProps={{ disabled: !editor?.providerKey.trim() || !providerValid }}
+        title={editor?.originalKey ? t('ohMyPi.editProvider') : t('ohMyPi.addProvider')}
+        width={720}
+        destroyOnHidden
+      >
+        <Form layout="vertical">
+          <Form.Item label={t('ohMyPi.providerKey')} required>
+            <Input
+              value={editor?.providerKey}
+              onChange={(event) => setEditor((current) => current && ({ ...current, providerKey: event.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label={t('ohMyPi.providerConfig')} required>
+            <JsonEditor
+              value={editor?.provider}
+              height={360}
+              onChange={(value, valid) => {
+                setProviderValid(valid);
+                if (valid) setEditor((current) => current && ({ ...current, provider: asRecord(value) }));
+              }}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default OhMyPiConfigModal;

--- a/web/features/coding/pi/pages/PiPage.tsx
+++ b/web/features/coding/pi/pages/PiPage.tsx
@@ -121,6 +121,7 @@ import type { OpenCodeModel, OpenCodeProvider } from '@/types/opencode';
 
 import ImportFromAllApiHubModal from '../components/ImportFromAllApiHubModal';
 import PiExtensionsSection from '../components/PiExtensionsSection';
+import OhMyPiConfigModal from '../components/OhMyPiConfigModal';
 import styles from './PiPage.module.less';
 
 const { Title, Text, Link } = Typography;
@@ -572,6 +573,7 @@ const PiPage: React.FC = () => {
   const [otherSettingsValid, setOtherSettingsValid] = React.useState(true);
   const [previewModalOpen, setPreviewModalOpen] = React.useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = React.useState(false);
+  const [ohMyPiModalOpen, setOhMyPiModalOpen] = React.useState(false);
   const [deleteScopeProvider, setDeleteScopeProvider] = React.useState<PiRuntimeProviderView | null>(null);
   const modelSettingsSaveSeqRef = React.useRef(0);
   const sidebarHidden = sidebarHiddenByPage.pi;
@@ -1844,6 +1846,9 @@ const PiPage: React.FC = () => {
                 >
                   <EyeOutlined /> {t('common.previewConfig')}
                 </Link>
+                <Button size="small" onClick={() => setOhMyPiModalOpen(true)}>
+                  {t('ohMyPi.title')}
+                </Button>
               </div>
               <Space className={styles.pathToolbar} wrap>
                 <Text type="secondary" className={styles.pathLabel}>
@@ -2406,6 +2411,7 @@ const PiPage: React.FC = () => {
             await setSidebarHidden('pi', !visible);
           }}
         />
+        <OhMyPiConfigModal open={ohMyPiModalOpen} onClose={() => setOhMyPiModalOpen(false)} />
       </SectionSidebarLayout>
     </Spin>
   );

--- a/web/i18n/locales/en-US.json
+++ b/web/i18n/locales/en-US.json
@@ -17,6 +17,18 @@
     "pi": "Pi",
     "grok": "Grok"
   },
+  "ohMyPi": {
+    "title": "Oh My Pi",
+    "rootDir": "Runtime root",
+    "providers": "Model providers",
+    "providerKey": "Provider ID",
+    "providerConfig": "Provider config",
+    "addProvider": "Add OMP provider",
+    "editProvider": "Edit OMP provider",
+    "deleteTitle": "Delete this OMP provider?",
+    "overrideOnly": "Built-in provider override",
+    "loadFailed": "Failed to load Oh My Pi config"
+  },
   "providerBilling": {
     "title": "Billing Config",
     "useCustom": "Use custom config",

--- a/web/i18n/locales/zh-CN.json
+++ b/web/i18n/locales/zh-CN.json
@@ -17,6 +17,18 @@
     "pi": "Pi",
     "grok": "Grok"
   },
+  "ohMyPi": {
+    "title": "Oh My Pi",
+    "rootDir": "运行时根目录",
+    "providers": "模型供应商",
+    "providerKey": "供应商 ID",
+    "providerConfig": "供应商配置",
+    "addProvider": "添加 OMP 供应商",
+    "editProvider": "编辑 OMP 供应商",
+    "deleteTitle": "删除这个 OMP 供应商？",
+    "overrideOnly": "仅覆盖内置供应商",
+    "loadFailed": "读取 Oh My Pi 配置失败"
+  },
   "providerBilling": {
     "title": "计费配置",
     "useCustom": "使用单独配置",

--- a/web/services/ohMyPiApi.ts
+++ b/web/services/ohMyPiApi.ts
@@ -1,0 +1,23 @@
+import { invoke } from '@tauri-apps/api/core';
+import type {
+  OmpProviderInput,
+  OmpRuntimeConfig,
+  OmpSettingsConfig,
+  OmpSettingsConfigInput,
+} from '@/types/ohMyPi';
+
+export const getOmpSettingsConfig = async (): Promise<OmpSettingsConfig | null> =>
+  invoke<OmpSettingsConfig | null>('get_omp_settings_config');
+
+export const saveOmpSettingsConfig = async (input: OmpSettingsConfigInput): Promise<void> => {
+  await invoke('save_omp_settings_config', { input });
+};
+
+export const readOmpRuntimeConfig = async (): Promise<OmpRuntimeConfig> =>
+  invoke<OmpRuntimeConfig>('read_omp_runtime_config');
+
+export const saveOmpProvider = async (input: OmpProviderInput): Promise<OmpRuntimeConfig> =>
+  invoke<OmpRuntimeConfig>('save_omp_provider', { input });
+
+export const deleteOmpProvider = async (providerKey: string): Promise<OmpRuntimeConfig> =>
+  invoke<OmpRuntimeConfig>('delete_omp_provider', { providerKey });

--- a/web/types/ohMyPi.ts
+++ b/web/types/ohMyPi.ts
@@ -1,0 +1,27 @@
+export interface OmpPathInfo {
+  path: string;
+  source: 'custom' | 'env' | 'shell' | 'default';
+}
+
+export interface OmpSettingsConfig {
+  rootDir?: string | null;
+  updatedAt: string;
+}
+
+export interface OmpSettingsConfigInput {
+  rootDir?: string | null;
+  clearRootDir?: boolean;
+}
+
+export interface OmpRuntimeConfig {
+  rootPathInfo: OmpPathInfo;
+  modelsPath: string;
+  mcpPath: string;
+  models: Record<string, unknown>;
+  providers: Record<string, Record<string, unknown>>;
+}
+
+export interface OmpProviderInput {
+  providerKey: string;
+  provider: Record<string, unknown>;
+}


### PR DESCRIPTION
## 变更内容

- 在 Pi 页面增加 Oh My Pi 配置入口，支持独立运行时根目录（含 WSL UNC 路径）
- 读取和管理 `~/.omp/agent/models.yml` 中的 provider，精确 upsert/delete 并保留未知字段
- 将 Oh My Pi 注册为原生 MCP 同步目标，动态解析 `<OMP root>/mcp.json`
- 首次创建 OMP MCP 配置时写入官方 `$schema`，保留 `disabledServers` / `enabledServers` 等顶层字段
- 不接管 OMP 的 `config.yml` 和认证数据库，保持其 TUI/CLI 配置边界

## 验证

- `pnpm test`：290 passed
- `pnpm exec tsc --noEmit`：passed
- `pnpm build`：passed
- `cargo test coding::oh_my_pi::commands::tests`：3 passed
- `cargo test coding::mcp::config_sync::tests`：25 passed
- `cargo test`：1399 passed，10 failed，1 ignored；首个失败为现有 OpenCode session export 测试调用本机 CLI 后找不到 fixture session，其余 9 个为共享 test env lock poisoned 级联失败，与本次改动无关

Closes #235