### PR TITLE
feat(omp): enforce required thinking.mode in models.yml

### DIFF
--- a/tauri/src/coding/oh_my_pi/AGENTS.md
+++ b/tauri/src/coding/oh_my_pi/AGENTS.md
@@ -25,6 +25,7 @@
 - 写入 `modelRoles.default` 时必须是 `provider/modelId`(OMP `parseModelString` 按首个 `/` 拆分),裸 provider 无效。
 - 不要接管 `config.yml` 全部字段;其他设置编辑器隐藏并保留 `modelRoles`/`defaultThinkingLevel`/`extensions`/`enabledModels` 等受管键。
 - `defaultThinkingLevel` 的“清除”由 `OmpModelSettingsInput.clear_thinking_level` 显式驱动；前端空字符串不代表清除，避免用户在切换 provider/model 时误删全局思考级别。
+- OMP 的 `thinking.mode` 是其 schema 的必填字段(`ThinkingControlModeSchema`:effort/budget/google-level/anthropic-adaptive/anthropic-budget-effort)。生成带 `thinking` 块的模型时若缺 mode,整个 models.yml 校验失败、所有自定义 provider 被禁用。前端 `buildOmpThinkingFromPreset(variants, api)` 按 api 推断 mode(google 系→google-level、anthropic-messages/bedrock→anthropic-adaptive、其余→effort);后端 `normalize_omp_provider_for_omptype` 对旧数据/手写 JSON 缺 mode 时同样兜底补上。
 - WSL 场景下选中 `~/.omp` 目录且其 `agent` 子目录为有效运行时布局时,归一化为 `~/.omp/agent`。
 
 ## 最小验证

--- a/tauri/src/coding/oh_my_pi/commands.rs
+++ b/tauri/src/coding/oh_my_pi/commands.rs
@@ -244,6 +244,10 @@ fn normalize_omp_provider_for_omptype(provider: &mut Value) {
     let Some(provider_obj) = provider.as_object_mut() else {
         return;
     };
+    let provider_api = provider_obj
+        .get("api")
+        .and_then(Value::as_str)
+        .map(str::to_string);
     let Some(models) = provider_obj.get_mut("models").and_then(Value::as_array_mut) else {
         return;
     };
@@ -260,7 +264,39 @@ fn normalize_omp_provider_for_omptype(provider: &mut Value) {
             }
         }
         model_obj.remove("thinkingLevelMap");
+        // OMP 的 thinking schema 将 `mode` 视为必填,缺失时整个 models.yml
+        // 校验失败、所有自定义 provider 被禁用。这里按 provider api 兜底补上
+        // mode(前端已保证生成,兜底覆盖手动/旧数据),校验才可通过。
+        add_omp_thinking_mode(model_obj, provider_api.as_deref());
     }
+}
+
+/// OMP ThinkingControlModeSchema 允许的取值。
+const OMP_THINKING_MODES: [&str; 5] =
+    ["effort", "budget", "google-level", "anthropic-adaptive", "anthropic-budget-effort"];
+
+/// OMP `thinking` schema 里 mode 是必填字段。若模型带 `thinking` 块但缺
+/// `mode`(旧数据或用户手写 JSON),按 provider `api` 推断一个合理值(镜像上游
+/// `inferThinkingControlMode`);api 缺失/未知时回退 effort。
+fn add_omp_thinking_mode(model_obj: &mut Map<String, Value>, provider_api: Option<&str>) {
+    let Some(thinking) = model_obj
+        .get_mut("thinking")
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    if thinking.contains_key("mode") {
+        let mode = thinking["mode"].as_str().unwrap_or_default();
+        if OMP_THINKING_MODES.contains(&mode) {
+            return;
+        }
+    }
+    let mode = match provider_api {
+        Some("google-generative-ai" | "google-gemini-cli" | "google-vertex") => "google-level",
+        Some("anthropic-messages" | "bedrock-converse-stream") => "anthropic-adaptive",
+        _ => "effort",
+    };
+    thinking.insert("mode".to_string(), Value::String(mode.to_string()));
 }
 
 /// 从 config.yml 解析默认模型选择。
@@ -1101,6 +1137,81 @@ mod tests {
                 "cost": { "input": 0.1, "output": 0.3, "cacheRead": 0.1, "cacheWrite": 0.2 }
             })
         );
+    }
+
+    #[test]
+    fn normalize_omptype_backfills_missing_thinking_mode_from_api() {
+        let mut provider = json!({
+            "api": "openai-responses",
+            "models": [
+                { "id": "a", "reasoning": true, "thinking": { "efforts": ["low", "high"] } }
+            ]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(
+            provider["models"][0]["thinking"]["mode"],
+            json!("effort")
+        );
+
+        // openai-responses thinking may carry an explicit mode; must be preserved.
+        let mut provider = json!({
+            "api": "openai-responses",
+            "models": [
+                { "id": "a", "thinking": { "mode": "budget", "efforts": ["low", "high"] } }
+            ]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(
+            provider["models"][0]["thinking"]["mode"],
+            json!("budget")
+        );
+
+        // google api defaults to google-level.
+        let mut provider = json!({
+            "api": "google-generative-ai",
+            "models": [
+                { "id": "a", "reasoning": true, "thinking": { "efforts": ["low", "high"] } }
+            ]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(
+            provider["models"][0]["thinking"]["mode"],
+            json!("google-level")
+        );
+
+        // anthropic-messages defaults to anthropic-adaptive.
+        let mut provider = json!({
+            "api": "anthropic-messages",
+            "models": [
+                { "id": "a", "reasoning": true, "thinking": { "efforts": ["low", "high"] } }
+            ]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(
+            provider["models"][0]["thinking"]["mode"],
+            json!("anthropic-adaptive")
+        );
+
+        // Invalid mode value is replaced by the api-derived default.
+        let mut provider = json!({
+            "api": "openai-responses",
+            "models": [
+                { "id": "a", "thinking": { "mode": "bogus", "efforts": ["low"] } }
+            ]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(
+            provider["models"][0]["thinking"]["mode"],
+            json!("effort")
+        );
+
+        // No thinking block -> nothing added.
+        let mut provider = json!({
+            "api": "openai-responses",
+            "models": [{ "id": "a", "reasoning": true }]
+        });
+        normalize_omp_provider_for_omptype(&mut provider);
+        assert_eq!(provider["models"][0].get("thinking"), None);
     }
 
     #[test]

--- a/web/components/common/ModelFormModal/index.tsx
+++ b/web/components/common/ModelFormModal/index.tsx
@@ -1106,6 +1106,7 @@ const ModelFormModal: React.FC<ModelFormModalProps> = ({
                       height={180}
                       resizable
                       placeholder={`{
+    "mode": "effort",
     "efforts": ["low", "medium", "high"],
     "defaultLevel": "high"
 }`}

--- a/web/features/coding/oh_my_pi/pages/OhMyPiPage.tsx
+++ b/web/features/coding/oh_my_pi/pages/OhMyPiPage.tsx
@@ -336,9 +336,10 @@ const sdkNameToOmpApi = (sdkName?: string): string => {
 const buildOmpModelFromOpenCodeModel = (
   modelId: string,
   model: OpenCodeModel,
+  api?: string,
 ): Record<string, unknown> => {
   const inputTypes = (model.modalities?.input ?? []).filter((inputType) => PI_INPUT_TYPES.has(inputType));
-  const thinking = buildOmpThinkingFromPreset(model.variants);
+  const thinking = buildOmpThinkingFromPreset(model.variants, api);
 
   return {
     id: model.id || modelId,
@@ -356,13 +357,14 @@ const buildOmpModelsProviderFromOpenCodeProvider = (
 ): Record<string, unknown> => {
   const options = provider.options ?? {};
   const headers = asStringRecord(options.headers);
+  const api = sdkNameToOmpApi(provider.npm);
   const models = Object.entries(provider.models || {}).map(([modelId, model]) =>
-    buildOmpModelFromOpenCodeModel(modelId, model),
+    buildOmpModelFromOpenCodeModel(modelId, model, api),
   );
 
   return {
     ...(provider.name ? { name: provider.name } : {}),
-    api: sdkNameToOmpApi(provider.npm),
+    api,
     ...(options.baseURL ? { baseUrl: options.baseURL } : {}),
     ...(options.apiKey ? { apiKey: options.apiKey } : {}),
     ...(!isRecordEmpty(headers) ? { headers } : {}),
@@ -1338,7 +1340,7 @@ const OhMyPiPage: React.FC = () => {
     selectedModels.forEach((model) => {
       if (!currentModelIds.has(model.id)) {
         const matchedPresetModel = findPresetModelById(model.id, ompApiToSdkName(providerApi));
-        currentModels.push(buildFetchedOmpModel(model, matchedPresetModel));
+        currentModels.push(buildFetchedOmpModel(model, matchedPresetModel, providerApi));
       }
     });
 

--- a/web/features/coding/oh_my_pi/utils/ompFetchedModels.ts
+++ b/web/features/coding/oh_my_pi/utils/ompFetchedModels.ts
@@ -2,7 +2,6 @@ import type { FetchedModel } from '../../../../components/common/FetchModelsModa
 import type { PresetModel } from '../../../../constants/presetModels.ts';
 import { PI_INPUT_TYPES } from '../../../../utils/piModelMetadata.ts';
 import { buildOmpThinkingFromPreset } from '../../../../utils/ompModelMetadata.ts';
-
 const asRecord = (value: unknown): Record<string, unknown> => (
   value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -28,6 +27,7 @@ export const buildOmpModelFromPreset = (
   preset: PresetModel,
   modelId: string,
   fallbackName: string,
+  api?: string,
 ): Record<string, unknown> => {
   const inputTypes = (preset.modalities?.input ?? []).filter((inputType) => PI_INPUT_TYPES.has(inputType));
   const cost = asRecord(preset.cost);
@@ -48,7 +48,7 @@ export const buildOmpModelFromPreset = (
   if (cacheWriteCost !== undefined) {
     piCost.cacheWrite = cacheWriteCost;
   }
-  const ompThinking = buildOmpThinkingFromPreset(preset.variants);
+  const ompThinking = buildOmpThinkingFromPreset(preset.variants, api);
 
   return {
     id: modelId,
@@ -69,12 +69,14 @@ export const buildOmpModelFromPreset = (
 export const buildFetchedOmpModel = (
   fetchedModel: FetchedModel,
   matchedPresetModel?: PresetModel | null,
+  api?: string,
 ): Record<string, unknown> => {
   if (matchedPresetModel) {
     return buildOmpModelFromPreset(
       matchedPresetModel,
       fetchedModel.id,
       fetchedModel.name || fetchedModel.id,
+      api,
     );
   }
   return {

--- a/web/test/features/coding/oh_my_pi/utils/ompFetchedModels.test.ts
+++ b/web/test/features/coding/oh_my_pi/utils/ompFetchedModels.test.ts
@@ -56,12 +56,33 @@ test('buildFetchedOmpModel fills thinking from preset variants, not thinkingLeve
   const model = buildFetchedOmpModel(
     { id: 'deepseek-reasoner', name: 'DeepSeek Reasoner' },
     thinkingPreset,
+    'openai-responses',
   );
 
   assert.equal(model.id, 'deepseek-reasoner');
   assert.equal(model.name, 'DeepSeek Reasoner');
-  assert.deepEqual(model.thinking, { efforts: ['low', 'high', 'max'], defaultLevel: 'high' });
+  assert.deepEqual(model.thinking, { mode: 'effort', efforts: ['low', 'high', 'max'], defaultLevel: 'high' });
   assert.equal('thinkingLevelMap' in model, false);
+});
+
+test('buildFetchedOmpModel infers thinking mode from provider api', () => {
+  const anthropic = buildFetchedOmpModel(
+    { id: 'deepseek-reasoner' },
+    thinkingPreset,
+    'anthropic-messages',
+  );
+  assert.deepEqual(anthropic.thinking, {
+    mode: 'anthropic-adaptive',
+    efforts: ['low', 'high', 'max'],
+    defaultLevel: 'high',
+  });
+
+  const google = buildFetchedOmpModel(
+    { id: 'deepseek-reasoner' },
+    thinkingPreset,
+    'google-generative-ai',
+  );
+  assert.deepEqual((google.thinking as Record<string, unknown>)?.mode, 'google-level');
 });
 
 test('buildFetchedOmpModel omits thinking when preset has no variants', () => {

--- a/web/test/utils/ompModelMetadata.test.ts
+++ b/web/test/utils/ompModelMetadata.test.ts
@@ -7,6 +7,7 @@ import {
   buildOmpThinkingFromPreset,
   getOmpModelDefaultThinkingLevel,
   getOmpModelThinkingLevels,
+  inferOmpThinkingMode,
   normalizeOmpThinkingLevelKey,
 } from '../../utils/ompModelMetadata.ts';
 
@@ -61,12 +62,38 @@ test('getOmpModelDefaultThinkingLevel reads thinking.defaultLevel', () => {
   assert.equal(getOmpModelDefaultThinkingLevel({ reasoning: true }), undefined);
 });
 
-test('buildOmpThinkingFromPreset derives efforts and defaultLevel from variants', () => {
+test('buildOmpThinkingFromPreset derives efforts, defaultLevel, and mode from variants', () => {
   const thinking = buildOmpThinkingFromPreset({
     none: { reasoningEffort: 'none' },
     medium: { thinkingConfig: { thinkingLevel: 'medium' } },
     high: { disabled: true },
   });
   // none is not an OMP effort; high is disabled; only medium survives.
-  assert.deepEqual(thinking, { efforts: ['medium'] });
+  assert.deepEqual(thinking, { mode: 'effort', efforts: ['medium'] });
+});
+
+test('buildOmpThinkingFromPreset infers mode from provider api', () => {
+  const google = buildOmpThinkingFromPreset(
+    { low: { reasoningEffort: 'low' } },
+    'google-generative-ai',
+  );
+  assert.deepEqual(google?.mode, 'google-level');
+
+  const anthropic = buildOmpThinkingFromPreset(
+    { low: { reasoningEffort: 'low' } },
+    'anthropic-messages',
+  );
+  assert.deepEqual(anthropic?.mode, 'anthropic-adaptive');
+});
+
+test('inferOmpThinkingMode maps apis to mode defaults', () => {
+  assert.equal(inferOmpThinkingMode('openai-responses'), 'effort');
+  assert.equal(inferOmpThinkingMode('openai-completions'), 'effort');
+  assert.equal(inferOmpThinkingMode('openrouter'), 'effort');
+  assert.equal(inferOmpThinkingMode('google-generative-ai'), 'google-level');
+  assert.equal(inferOmpThinkingMode('google-vertex'), 'google-level');
+  assert.equal(inferOmpThinkingMode('anthropic-messages'), 'anthropic-adaptive');
+  assert.equal(inferOmpThinkingMode('bedrock-converse-stream'), 'anthropic-adaptive');
+  assert.equal(inferOmpThinkingMode(undefined), 'effort');
+  assert.equal(inferOmpThinkingMode('some-unknown-api'), 'effort');
 });

--- a/web/utils/ompModelMetadata.ts
+++ b/web/utils/ompModelMetadata.ts
@@ -27,6 +27,31 @@ const asStringArray = (value: unknown): string[] => (
   Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 );
 
+/** OMP `thinking.mode` 上游枚举(与 OMP ThinkingControlModeSchema 一致)。 */
+export const OMP_THINKING_MODE_KEYS = ['effort', 'budget', 'google-level', 'anthropic-adaptive', 'anthropic-budget-effort'] as const;
+export type OmpThinkingMode = (typeof OMP_THINKING_MODE_KEYS)[number];
+
+/**
+ * 按 OMP provider `api` 推断 `thinking.mode` 的合理默认值,镜像上游
+ * `inferThinkingControlMode`:google 系→google-level、anthropic-messages/
+ * bedrock-converse-stream→anthropic-adaptive、其余→effort。api 缺失或未知
+ * 时回退 effort。OMP 对 mode 校验严格(必填),生成的 thinking 必须带 mode,
+ * 否则整个 models.yml 校验失败、所有自定义 provider 被禁用。
+ */
+export const inferOmpThinkingMode = (api?: string): OmpThinkingMode => {
+  switch (api) {
+    case 'google-generative-ai':
+    case 'google-gemini-cli':
+    case 'google-vertex':
+      return 'google-level';
+    case 'anthropic-messages':
+    case 'bedrock-converse-stream':
+      return 'anthropic-adaptive';
+    default:
+      return 'effort';
+  }
+};
+
 /** 从 OMP 模型 `thinking` 结构推导可选思考级别列表(不含 off;off 表示关闭
  *  思考,由调用方作为独立选项处理,OMP 的 EffortSchema 词表为 minimal..max)。 */
 export const getOmpModelThinkingLevels = (
@@ -131,9 +156,13 @@ export const getPresetThinkingLevelValue = (
   return undefined;
 };
 
-/** 从 OpenCode preset variants 推导 OMP 的 `thinking` 结构(按 effort 聚合)。 */
+/** 从 OpenCode preset variants 推导 OMP 的 `thinking` 结构(按 effort 聚合)。
+ *  `mode` 由 OMP provider 的 `api` 推断(见 {@link inferOmpThinkingMode});api
+ *  未知时回退 effort。OMP 的 thinking schema 将 mode 视为必填,缺失会导致整个
+ *  models.yml 校验失败。 */
 export const buildOmpThinkingFromPreset = (
   variants: Record<string, OpenCodeModelVariant> | undefined,
+  api?: string,
 ): Record<string, unknown> | undefined => {
   if (!variants || Object.keys(variants).length === 0) {
     return undefined;
@@ -167,7 +196,7 @@ export const buildOmpThinkingFromPreset = (
     (left, right) =>
       OMP_THINKING_EFFORT_KEYS.indexOf(left as never) - OMP_THINKING_EFFORT_KEYS.indexOf(right as never),
   );
-  const thinking: Record<string, unknown> = { efforts };
+  const thinking: Record<string, unknown> = { mode: inferOmpThinkingMode(api), efforts };
   if (defaultLevel) {
     thinking.defaultLevel = defaultLevel;
   }


### PR DESCRIPTION
修复了在omp在设置推理强度时缺少thinking.mode的问题